### PR TITLE
Make WriteBlockAndSetHead emit head event

### DIFF
--- a/clients/geth/specular/rollup/services/sequencer/batcher.go
+++ b/clients/geth/specular/rollup/services/sequencer/batcher.go
@@ -153,9 +153,7 @@ func (b *Batcher) commitBlock() error {
 		logs = append(logs, receipt.Logs...)
 	}
 	// Write block to chain
-	// Do not emit headEvent, it will cause worker to try sealing even if it is
-	// not started
-	_, err := b.chain.WriteBlockAndSetHead(block, b.receipts, logs, b.state, false)
+	_, err := b.chain.WriteBlockAndSetHead(block, b.receipts, logs, b.state, true)
 	if err != nil {
 		return err
 	}

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -123,7 +123,7 @@ func (v *Validator) commitBlocks(blocks []*rollupTypes.SequenceBlock) (common.Ha
 			}
 			logs = append(logs, receipt.Logs...)
 		}
-		_, err := v.Chain.WriteBlockAndSetHead(block, receipts, logs, state, false)
+		_, err := v.Chain.WriteBlockAndSetHead(block, receipts, logs, state, true)
 		if err != nil {
 			return common.Hash{}, nil, err
 		}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Make all calls to `WriteBlockAndSetHead` emit head event

Notes:

- To make the transaction pool work correctly, chain head event needs to be emitted
- The worker will not start now since the configuration has changed long time ago
