### PR TITLE
Inbox sync & indexer service

### DIFF
--- a/clients/geth/specular/cmd/geth/main.go
+++ b/clients/geth/specular/cmd/geth/main.go
@@ -219,6 +219,7 @@ var (
 		specularUtils.RollupSequencerInboxAddrFlag,
 		specularUtils.RollupRollupAddrFlag,
 		specularUtils.RollupRollupStakeAmount,
+		specularUtils.RollupL1RollupGenesisBlock,
 	}
 	// <specular modification/>
 )

--- a/clients/geth/specular/cmd/utils/flags.go
+++ b/clients/geth/specular/cmd/utils/flags.go
@@ -76,6 +76,11 @@ var (
 		Usage: "The contract address of L1 rollup",
 		Value: "",
 	}
+	RollupL1RollupGenesisBlock = &cli.Uint64Flag{
+		Name:  "rollup.l1-rollup-genesis-block",
+		Usage: "The block number of L1 rollup genesis block to sync from",
+		Value: 0,
+	}
 	RollupRollupStakeAmount = &cli.Uint64Flag{
 		Name:  "rollup.rollup-stake-amount",
 		Usage: "Required staking amount",
@@ -129,15 +134,16 @@ func MakeRollupConfig(ctx *cli.Context) *rollup.Config {
 		utils.Fatalf("Failed to register the Rollup service: coinbase account locked")
 	}
 	cfg := &rollup.Config{
-		Node:               ctx.String(RollupNodeFlag.Name),
-		Coinbase:           common.HexToAddress(ctx.String(RollupCoinBaseFlag.Name)),
-		Passphrase:         passphrase,
-		L1Endpoint:         ctx.String(RollupL1EndpointFlag.Name),
-		L1ChainID:          ctx.Uint64(RollupL1ChainIDFlag.Name),
-		SequencerAddr:      common.HexToAddress(ctx.String(RollupSequencerAddrFlag.Name)),
-		SequencerInboxAddr: common.HexToAddress(ctx.String(RollupSequencerInboxAddrFlag.Name)),
-		RollupAddr:         common.HexToAddress(ctx.String(RollupRollupAddrFlag.Name)),
-		RollupStakeAmount:  ctx.Uint64(RollupRollupStakeAmount.Name),
+		Node:                 ctx.String(RollupNodeFlag.Name),
+		Coinbase:             common.HexToAddress(ctx.String(RollupCoinBaseFlag.Name)),
+		Passphrase:           passphrase,
+		L1Endpoint:           ctx.String(RollupL1EndpointFlag.Name),
+		L1ChainID:            ctx.Uint64(RollupL1ChainIDFlag.Name),
+		SequencerAddr:        common.HexToAddress(ctx.String(RollupSequencerAddrFlag.Name)),
+		SequencerInboxAddr:   common.HexToAddress(ctx.String(RollupSequencerInboxAddrFlag.Name)),
+		RollupAddr:           common.HexToAddress(ctx.String(RollupRollupAddrFlag.Name)),
+		L1RollupGenesisBlock: ctx.Uint64(RollupL1RollupGenesisBlock.Name),
+		RollupStakeAmount:    ctx.Uint64(RollupRollupStakeAmount.Name),
 	}
 	return cfg
 }

--- a/clients/geth/specular/rollup/service.go
+++ b/clients/geth/specular/rollup/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/specularl2/specular/clients/geth/specular/proof"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services"
+	"github.com/specularl2/specular/clients/geth/specular/rollup/services/indexer"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services/sequencer"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services/validator"
 )
@@ -41,6 +42,8 @@ func RegisterRollupService(stack *node.Node, eth services.Backend, proofBackend 
 		sequencer.RegisterService(stack, eth, proofBackend, cfg, auth)
 	} else if cfg.Node == services.NODE_VALIDATOR {
 		validator.RegisterService(stack, eth, proofBackend, cfg, auth)
+	} else if cfg.Node == services.NODE_INDEXER {
+		indexer.RegisterService(stack, eth, proofBackend, cfg, auth)
 	} else {
 		log.Crit("Failed to register the Rollup service: Node type unkown", "type", cfg.Node)
 	}

--- a/clients/geth/specular/rollup/services/base.go
+++ b/clients/geth/specular/rollup/services/base.go
@@ -104,8 +104,8 @@ func NewBaseService(eth Backend, proofBackend proof.Backend, cfg *Config, auth *
 }
 
 // Start starts the rollup service
-// If cleanL1 is true, the service will only start from a celan L1 history
-// If stake is true, the service will try stake on start
+// If cleanL1 is true, the service will only start from a clean L1 history
+// If stake is true, the service will try to stake on start
 // Returns the genesis block
 func (b *BaseService) Start(cleanL1, stake bool) *types.Block {
 	// Check if we are at genesis

--- a/clients/geth/specular/rollup/services/base.go
+++ b/clients/geth/specular/rollup/services/base.go
@@ -103,28 +103,34 @@ func NewBaseService(eth Backend, proofBackend proof.Backend, cfg *Config, auth *
 	return b, nil
 }
 
-func (b *BaseService) Start() *types.Block {
+func (b *BaseService) Start(cleanL1, stake bool) *types.Block {
 	// Check if we are at genesis
 	// TODO: if not, sync from L1
 	genesis := b.Eth.BlockChain().CurrentBlock()
 	if genesis.NumberU64() != 0 {
-		log.Crit("Sequencer can only start from genesis")
+		log.Crit("Rollup service can only start from clean history")
 	}
 	log.Info("Genesis root", "root", genesis.Root())
-	inboxSize, err := b.Inbox.GetInboxSize()
-	if err != nil {
-		log.Crit("Failed to get initial inbox size", "err", err)
+
+	if cleanL1 {
+		inboxSize, err := b.Inbox.GetInboxSize()
+		if err != nil {
+			log.Crit("Failed to get initial inbox size", "err", err)
+		}
+		if inboxSize.Cmp(common.Big0) != 0 {
+			log.Crit("Rollup service can only start from genesis")
+		}
 	}
-	if inboxSize.Cmp(common.Big0) != 0 {
-		log.Crit("Sequencer can only start from genesis")
-	}
-	// Initial staking
-	// TODO: sync L1 staking status
-	stakeOpts := b.Rollup.TransactOpts
-	stakeOpts.Value = big.NewInt(int64(b.Config.RollupStakeAmount))
-	_, err = b.Rollup.Contract.Stake(&stakeOpts)
-	if err != nil {
-		log.Crit("Failed to stake", "err", err)
+
+	if stake {
+		// Initial staking
+		// TODO: sync L1 staking status
+		stakeOpts := b.Rollup.TransactOpts
+		stakeOpts.Value = big.NewInt(int64(b.Config.RollupStakeAmount))
+		_, err := b.Rollup.Contract.Stake(&stakeOpts)
+		if err != nil {
+			log.Crit("Failed to stake", "err", err)
+		}
 	}
 	return genesis
 }

--- a/clients/geth/specular/rollup/services/base.go
+++ b/clients/geth/specular/rollup/services/base.go
@@ -103,6 +103,10 @@ func NewBaseService(eth Backend, proofBackend proof.Backend, cfg *Config, auth *
 	return b, nil
 }
 
+// Start starts the rollup service
+// If cleanL1 is true, the service will only start from a celan L1 history
+// If stake is true, the service will try stake on start
+// Returns the genesis block
 func (b *BaseService) Start(cleanL1, stake bool) *types.Block {
 	// Check if we are at genesis
 	// TODO: if not, sync from L1

--- a/clients/geth/specular/rollup/services/config.go
+++ b/clients/geth/specular/rollup/services/config.go
@@ -7,17 +7,19 @@ import (
 const (
 	NODE_SEQUENCER = "sequencer"
 	NODE_VALIDATOR = "validator"
+	NODE_INDEXER   = "indexer"
 )
 
 // Config is the configuration of rollup services
 type Config struct {
-	Node               string         // Rollup node type, either sequencer or validator
-	Coinbase           common.Address // The account used for L1 and L2 activity
-	Passphrase         string         // The passphrase of the coinbase account
-	L1Endpoint         string         // L1 API endpoint
-	L1ChainID          uint64         // L1 chain ID
-	SequencerAddr      common.Address // Validator only
-	SequencerInboxAddr common.Address // L1 SequencerInbox contract address
-	RollupAddr         common.Address // L1 Rollup contract address
-	RollupStakeAmount  uint64         // Amount of stake
+	Node                 string         // Rollup node type, either sequencer or validator
+	Coinbase             common.Address // The account used for L1 and L2 activity
+	Passphrase           string         // The passphrase of the coinbase account
+	L1Endpoint           string         // L1 API endpoint
+	L1ChainID            uint64         // L1 chain ID
+	SequencerAddr        common.Address // Validator only
+	SequencerInboxAddr   common.Address // L1 SequencerInbox contract address
+	RollupAddr           common.Address // L1 Rollup contract address
+	L1RollupGenesisBlock uint64         // L1 Rollup genesis block
+	RollupStakeAmount    uint64         // Amount of stake
 }

--- a/clients/geth/specular/rollup/services/indexer/indexer.go
+++ b/clients/geth/specular/rollup/services/indexer/indexer.go
@@ -1,0 +1,72 @@
+package indexer
+
+import (
+	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/specularl2/specular/clients/geth/specular/proof"
+	"github.com/specularl2/specular/clients/geth/specular/rollup/services"
+)
+
+func RegisterService(stack *node.Node, eth services.Backend, proofBackend proof.Backend, cfg *services.Config, auth *bind.TransactOpts) {
+	indexer, err := New(eth, proofBackend, cfg, auth)
+	if err != nil {
+		log.Crit("Failed to register the Rollup service", "err", err)
+	}
+	stack.RegisterLifecycle(indexer)
+	// stack.RegisterAPIs(indexer.APIs())
+	log.Info("Indexer registered")
+}
+
+type Indexer struct {
+	*services.BaseService
+
+	newBatchCh chan struct{}
+}
+
+func New(eth services.Backend, proofBackend proof.Backend, cfg *services.Config, auth *bind.TransactOpts) (*Indexer, error) {
+	base, err := services.NewBaseService(eth, proofBackend, cfg, auth)
+	if err != nil {
+		return nil, err
+	}
+	s := &Indexer{
+		BaseService: base,
+		newBatchCh:  make(chan struct{}, 1),
+	}
+	return s, nil
+}
+
+func (i *Indexer) newBatchConsumeLoop() {
+	defer i.Wg.Done()
+	for {
+		select {
+		case <-i.newBatchCh:
+			continue
+		case <-i.Ctx.Done():
+			return
+		}
+	}
+}
+
+func (i *Indexer) Start() error {
+	i.BaseService.Start(false, false)
+
+	i.Wg.Add(2)
+	go i.newBatchConsumeLoop()
+	go i.SyncLoop(i.newBatchCh)
+	log.Info("Indexer started")
+	return nil
+}
+
+func (i *Indexer) Stop() error {
+	log.Info("Indexer stopped")
+	i.Cancel()
+	i.Wg.Wait()
+	return nil
+}
+
+func (i *Indexer) APIs() []rpc.API {
+	// TODO: sequencer APIs
+	return []rpc.API{}
+}

--- a/clients/geth/specular/rollup/services/sequencer/batcher.go
+++ b/clients/geth/specular/rollup/services/sequencer/batcher.go
@@ -183,16 +183,6 @@ func (b *Batcher) startNewBlock() error {
 	}
 	state, err := b.chain.StateAt(parent.Root())
 	if err != nil {
-		// Note since the sealing block can be created upon the arbitrary parent
-		// block, but the state of parent block may already be pruned, so the necessary
-		// state recovery is needed here in the future.
-		//
-		// The maximum acceptable reorg depth can be limited by the finalised block
-		// somehow. TODO(rjl493456442) fix the hard-coded number here later.
-		state, err = b.eth.StateAtBlock(parent, 1024, nil, false, false)
-		log.Warn("Recovered mining state", "root", parent.Root(), "err", err)
-	}
-	if err != nil {
 		return err
 	}
 	state.StartPrefetcher("sequencer")

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -433,7 +433,7 @@ func (s *Sequencer) challengeLoop() {
 }
 
 func (s *Sequencer) Start() error {
-	genesis := s.BaseService.Start()
+	genesis := s.BaseService.Start(true, true)
 
 	s.Wg.Add(4)
 	go s.batchingLoop()

--- a/clients/geth/specular/rollup/services/sync.go
+++ b/clients/geth/specular/rollup/services/sync.go
@@ -47,7 +47,7 @@ func (b *BaseService) CommitBlocks(blocks []*rollupTypes.SequenceBlock) error {
 		header := &types.Header{
 			ParentHash: parent.Hash(),
 			Number:     new(big.Int).SetUint64(sblock.BlockNumber),
-			GasLimit:   core.CalcGasLimit(parent.GasLimit(), ethconfig.Defaults.Miner.GasCeil), // TODO: this may cause problem
+			GasLimit:   core.CalcGasLimit(parent.GasLimit(), ethconfig.Defaults.Miner.GasCeil), // TODO: this may cause problem if the gas limit generated on sequencer side mismatch with this one
 			Time:       sblock.Timestamp,
 			Coinbase:   b.Config.SequencerAddr,
 			Difficulty: common.Big1, // Fake difficulty. Avoid use 0 here because it means the merge happened

--- a/clients/geth/specular/rollup/services/sync.go
+++ b/clients/geth/specular/rollup/services/sync.go
@@ -18,7 +18,7 @@ import (
 	rollupTypes "github.com/specularl2/specular/clients/geth/specular/rollup/types"
 )
 
-var syncRange uint64 = 10000
+const syncRange uint64 = 10000
 
 // CommitBlocks executes and commits sequenced blocks to local blockchain
 // TODO: this function shares a lot of codes with Batcher

--- a/clients/geth/specular/rollup/services/sync.go
+++ b/clients/geth/specular/rollup/services/sync.go
@@ -1,0 +1,249 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/specularl2/specular/clients/geth/specular/bindings"
+	rollupTypes "github.com/specularl2/specular/clients/geth/specular/rollup/types"
+)
+
+var syncRange uint64 = 10000
+
+// CommitBlocks executes and commits sequenced blocks to local blockchain
+// TODO: this function shares a lot of codes with Batcher
+// TODO: use StateProcessor::Process() instead
+func (b *BaseService) CommitBlocks(blocks []*rollupTypes.SequenceBlock) error {
+	if len(blocks) == 0 {
+		return nil
+	}
+	chainConfig := b.Chain.Config()
+	parent := b.Chain.CurrentBlock()
+	if parent == nil {
+		return fmt.Errorf("missing parent")
+	}
+	num := parent.Number()
+	if num.Uint64() != blocks[0].BlockNumber-1 {
+		return fmt.Errorf("rollup services unsynced")
+	}
+	state, err := b.Chain.StateAt(parent.Root())
+	if err != nil {
+		return err
+	}
+	state.StartPrefetcher("rollup")
+	defer state.StopPrefetcher()
+
+	for _, sblock := range blocks {
+		header := &types.Header{
+			ParentHash: parent.Hash(),
+			Number:     new(big.Int).SetUint64(sblock.BlockNumber),
+			GasLimit:   core.CalcGasLimit(parent.GasLimit(), ethconfig.Defaults.Miner.GasCeil), // TODO: this may cause problem
+			Time:       sblock.Timestamp,
+			Coinbase:   b.Config.SequencerAddr,
+			Difficulty: common.Big1, // Fake difficulty. Avoid use 0 here because it means the merge happened
+		}
+		gasPool := new(core.GasPool).AddGas(header.GasLimit)
+		var receipts []*types.Receipt
+		for idx, tx := range sblock.Txs {
+			state.Prepare(tx.Hash(), idx)
+			receipt, err := core.ApplyTransaction(chainConfig, b.Chain, &b.Config.SequencerAddr, gasPool, state, header, tx, &header.GasUsed, *b.Chain.GetVMConfig())
+			if err != nil {
+				return err
+			}
+			receipts = append(receipts, receipt)
+		}
+		// Finalize header
+		header.Root = state.IntermediateRoot(b.Chain.Config().IsEIP158(header.Number))
+		header.UncleHash = types.CalcUncleHash(nil)
+		// Assemble block
+		block := types.NewBlock(header, sblock.Txs, nil, receipts, trie.NewStackTrie(nil))
+		hash := block.Hash()
+		// Finalize receipts and logs
+		var logs []*types.Log
+		for i, receipt := range receipts {
+			// Add block location fields
+			receipt.BlockHash = hash
+			receipt.BlockNumber = block.Number()
+			receipt.TransactionIndex = uint(i)
+
+			// Update the block hash in all logs since it is now available and not when the
+			// receipt/log of individual transactions were created.
+			for _, log := range receipt.Logs {
+				log.BlockHash = hash
+			}
+			logs = append(logs, receipt.Logs...)
+		}
+		_, err := b.Chain.WriteBlockAndSetHead(block, receipts, logs, state, true)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func batchEventToSequenceBlocks(l1 *ethclient.Client, abi *abi.ABI, ev *bindings.ISequencerInboxTxBatchAppended) ([]*rollupTypes.SequenceBlock, error) {
+	// New appendTxBatch call
+	tx, _, err := l1.TransactionByHash(context.Background(), ev.Raw.TxHash)
+	if err != nil {
+		return nil, err
+	}
+	// Decode input from abi
+	decoded, err := abi.Methods["appendTxBatch"].Inputs.Unpack(tx.Data()[4:])
+	if err != nil {
+		return nil, err
+	}
+	// Construct batch
+	batch, err := rollupTypes.TxBatchFromDecoded(decoded)
+	if err != nil {
+		return nil, err
+	}
+	// Split batch into blocks
+	txNum := 0
+	blocks := make([]*rollupTypes.SequenceBlock, 0, len(batch.Contexts))
+	for _, ctx := range batch.Contexts {
+		block := &rollupTypes.SequenceBlock{
+			SequenceContext: ctx,
+			Txs:             batch.Txs[txNum : txNum+int(ctx.NumTxs)],
+		}
+		blocks = append(blocks, block)
+		txNum += int(ctx.NumTxs)
+	}
+	return blocks, nil
+}
+
+// SyncInbox syncs inbox events in L1 block range [start, end)
+func (b *BaseService) SyncInbox(start, end uint64) error {
+	log.Info("Syncing inbox", "start", start, "end", end)
+	abi, err := bindings.ISequencerInboxMetaData.GetAbi()
+	if err != nil {
+		log.Crit("Failed to get ISequencerInbox ABI", "err", err)
+	}
+	currentBlock := start
+	for currentBlock < end {
+		currentEpochEnd := currentBlock + syncRange
+		if currentEpochEnd >= end {
+			currentEpochEnd = end - 1
+		}
+		log.Info("Syncing inbox", "currentBlock", currentBlock, "epoch end", currentEpochEnd)
+		opts := &bind.FilterOpts{
+			Start:   currentBlock,
+			End:     &currentEpochEnd,
+			Context: b.Ctx,
+		}
+		logIterator, err := b.Inbox.Contract.FilterTxBatchAppended(opts)
+		if err != nil {
+			log.Crit("Failed to get TxBatchAppended event", "err", err)
+		}
+		for logIterator.Next() {
+			ev := logIterator.Event
+			blocks, err := batchEventToSequenceBlocks(b.L1, abi, ev)
+			if err != nil {
+				log.Crit("Failed to convert batch event to sequence blocks", "err", err)
+			}
+			// Commit blocks to blockchain
+			err = b.CommitBlocks(blocks)
+			if err != nil {
+				return err
+			}
+		}
+		if err := logIterator.Error(); err != nil {
+			log.Crit("Failed to get TxBatchAppended event", "err", err)
+		}
+		currentBlock = currentEpochEnd + 1
+	}
+	return nil
+}
+
+func (b *BaseService) SyncLoop(newBatchCh chan<- struct{}) {
+	defer b.Wg.Done()
+
+	// Get current block number
+	currentBlock := b.Config.L1RollupGenesisBlock
+	// Get L1 block head
+	l1BlockHead, err := b.L1.BlockNumber(b.Ctx)
+	if err != nil {
+		log.Crit("Failed to get L1 block head", "err", err)
+	}
+	// Sync inbox untill the current l1 block head
+	err = b.SyncInbox(currentBlock, l1BlockHead)
+	if err != nil {
+		log.Crit("Failed to sync inbox", "err", err)
+	}
+	currentBlock = l1BlockHead
+
+	abi, err := bindings.ISequencerInboxMetaData.GetAbi()
+	if err != nil {
+		log.Crit("Failed to get ISequencerInbox ABI", "err", err)
+	}
+
+	// Listen to TxBatchAppendEvent
+	batchEventCh := make(chan *bindings.ISequencerInboxTxBatchAppended, 4096)
+	batchEventSub, err := b.Inbox.Contract.WatchTxBatchAppended(&bind.WatchOpts{Context: b.Ctx}, batchEventCh)
+	if err != nil {
+		log.Crit("Failed to watch rollup event", "err", err)
+	}
+	defer batchEventSub.Unsubscribe()
+
+	// Get L1 block head again and sync to it
+	l1BlockHead, err = b.L1.BlockNumber(b.Ctx)
+	if err != nil {
+		log.Crit("Failed to get L1 block head", "err", err)
+	}
+
+	syncedCh := make(chan struct{})
+	synced := false
+
+	if l1BlockHead > currentBlock {
+		go func() {
+			err = b.SyncInbox(currentBlock, l1BlockHead)
+			if err != nil {
+				log.Crit("Failed to sync inbox", "err", err)
+			}
+			close(syncedCh)
+		}()
+	} else {
+		close(syncedCh)
+	}
+
+	pendingBlocks := make([]*rollupTypes.SequenceBlock, 0)
+
+	for {
+		select {
+		case <-syncedCh:
+			syncedCh = nil
+			synced = true
+			// Commit pending blocks
+			err = b.CommitBlocks(pendingBlocks)
+			if err != nil {
+				log.Crit("Failed to commit blocks", "err", err)
+			}
+		case ev := <-batchEventCh:
+			blocks, err := batchEventToSequenceBlocks(b.L1, abi, ev)
+			if err != nil {
+				log.Crit("Failed to convert batch event to sequence blocks", "err", err)
+			}
+			if synced {
+				// Commit blocks to blockchain
+				err = b.CommitBlocks(blocks)
+				if err != nil {
+					log.Crit("Failed to commit blocks", "err", err)
+				}
+				newBatchCh <- struct{}{}
+			} else {
+				pendingBlocks = append(pendingBlocks, blocks...)
+			}
+		case <-b.Ctx.Done():
+			return
+		}
+	}
+}

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -1,18 +1,16 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/trie"
 	"github.com/specularl2/specular/clients/geth/specular/bindings"
 	"github.com/specularl2/specular/clients/geth/specular/proof"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services"
@@ -25,13 +23,15 @@ type challengeCtx struct {
 	confirmedAssertion *rollupTypes.Assertion
 }
 
-// TODO: abstract the common field/init to a base service
+var errAssertionOverflowedInbox = fmt.Errorf("assertion overflowed inbox")
+var errValidationFailed = fmt.Errorf("validation failed")
+
 type Validator struct {
 	*services.BaseService
 
-	batchCh              chan *rollupTypes.TxBatch
+	newBatchCh           chan struct{}
 	challengeCh          chan *challengeCtx
-	challengeResoutionCh chan struct{}
+	challengeResoutionCh chan *rollupTypes.Assertion
 }
 
 // TODO: this shares a lot of code with sequencer
@@ -42,141 +42,58 @@ func New(eth services.Backend, proofBackend proof.Backend, cfg *services.Config,
 	}
 	v := &Validator{
 		BaseService:          base,
-		batchCh:              make(chan *rollupTypes.TxBatch, 4096),
+		newBatchCh:           make(chan struct{}, 4096),
 		challengeCh:          make(chan *challengeCtx),
-		challengeResoutionCh: make(chan struct{}),
+		challengeResoutionCh: make(chan *rollupTypes.Assertion),
 	}
 	return v, nil
 }
 
-// commitBlocks executes and commits sequenced blocks to local blockchain
-// It returns the afterwards state hash and total gas used for these blocks
-// TODO: this function shares a lot of codes with Batcher
-// TODO: use StateProcessor::Process() instead
-func (v *Validator) commitBlocks(blocks []*rollupTypes.SequenceBlock) (common.Hash, *big.Int, error) {
-	var targetVmHash common.Hash
-	targetGasUsed := new(big.Int)
-	chainConfig := v.Chain.Config()
-	parent := v.Chain.CurrentBlock()
-	if parent == nil {
-		return common.Hash{}, nil, fmt.Errorf("missing parent")
+// This function will try to validate a pending assertion
+func (v *Validator) tryVaidateAssertion(confirmedAssertion, assertion *rollupTypes.Assertion) error {
+	// Find asserted blocks in local blockchain
+	inboxSizeDiff := new(big.Int).Sub(assertion.InboxSize, confirmedAssertion.InboxSize)
+	currentBlockNum := assertion.StartBlock
+	currentChainHeight := v.Chain.CurrentBlock().NumberU64()
+	var block *types.Block
+	targetGasUsed := new(big.Int).Set(confirmedAssertion.CumulativeGasUsed)
+	for inboxSizeDiff.Cmp(common.Big0) > 0 {
+		if currentBlockNum > currentChainHeight {
+			return errAssertionOverflowedInbox
+		}
+		block = v.Chain.GetBlockByNumber(currentBlockNum)
+		if block == nil {
+			return errAssertionOverflowedInbox
+		}
+		numTxs := uint64(len(block.Transactions()))
+		if numTxs > inboxSizeDiff.Uint64() {
+			log.Crit("UNHANDELED: Assertion created in the middle of block, validator state corrupted!")
+		}
+		targetGasUsed.Add(targetGasUsed, new(big.Int).SetUint64(block.GasUsed()))
+		inboxSizeDiff = new(big.Int).Sub(inboxSizeDiff, new(big.Int).SetUint64(numTxs))
+		currentBlockNum++
 	}
-	num := parent.Number()
-	if num.Uint64() != blocks[0].BlockNumber-1 {
-		return common.Hash{}, nil, fmt.Errorf("validator unsynced")
+	assertion.EndBlock = currentBlockNum - 1
+	targetVmHash := block.Root()
+	if targetVmHash != assertion.VmHash || targetGasUsed.Cmp(assertion.CumulativeGasUsed) != 0 {
+		// Validation failed
+		ourAssertion := &rollupTypes.Assertion{
+			VmHash:                targetVmHash,
+			CumulativeGasUsed:     targetGasUsed,
+			InboxSize:             assertion.InboxSize,
+			StartBlock:            assertion.StartBlock,
+			EndBlock:              assertion.EndBlock,
+			PrevCumulativeGasUsed: new(big.Int).Set(confirmedAssertion.CumulativeGasUsed),
+		}
+		v.challengeCh <- &challengeCtx{assertion, ourAssertion, confirmedAssertion}
+		return errValidationFailed
 	}
-	state, err := v.Chain.StateAt(parent.Root())
-	// TODO: in newest version of geth, below codes are removed
+	// Validation succeeded, confirm assertion and advance stake
+	_, err := v.Rollup.AdvanceStake(assertion.ID)
 	if err != nil {
-		// Note since the sealing block can be created upon the arbitrary parent
-		// block, but the state of parent block may already be pruned, so the necessary
-		// state recovery is needed here in the future.
-		//
-		// The maximum acceptable reorg depth can be limited by the finalised block
-		// somehow. TODO(rjl493456442) fix the hard-coded number here later.
-		state, err = v.Eth.StateAtBlock(parent, 1024, nil, false, false)
-		log.Warn("Recovered mining state", "root", parent.Root(), "err", err)
+		log.Crit("UNHANDELED: Can't advance stake, validator state corrupted", "err", err)
 	}
-	if err != nil {
-		return common.Hash{}, nil, err
-	}
-	state.StartPrefetcher("validator")
-	defer state.StopPrefetcher()
-
-	for _, sblock := range blocks {
-		header := &types.Header{
-			ParentHash: parent.Hash(),
-			Number:     new(big.Int).SetUint64(sblock.BlockNumber),
-			GasLimit:   core.CalcGasLimit(parent.GasLimit(), ethconfig.Defaults.Miner.GasCeil), // TODO: this may cause problem
-			Time:       sblock.Timestamp,
-			Coinbase:   v.Config.SequencerAddr,
-			Difficulty: common.Big1, // Fake difficulty. Avoid use 0 here because it means the merge happened
-		}
-		gasPool := new(core.GasPool).AddGas(header.GasLimit)
-		var receipts []*types.Receipt
-		for idx, tx := range sblock.Txs {
-			state.Prepare(tx.Hash(), idx)
-			receipt, err := core.ApplyTransaction(chainConfig, v.Chain, &v.Config.SequencerAddr, gasPool, state, header, tx, &header.GasUsed, *v.Chain.GetVMConfig())
-			if err != nil {
-				return common.Hash{}, nil, err
-			}
-			receipts = append(receipts, receipt)
-		}
-		// Finalize header
-		header.Root = state.IntermediateRoot(v.Chain.Config().IsEIP158(header.Number))
-		header.UncleHash = types.CalcUncleHash(nil)
-		// Assemble block
-		block := types.NewBlock(header, sblock.Txs, nil, receipts, trie.NewStackTrie(nil))
-		hash := block.Hash()
-		// Finalize receipts and logs
-		var logs []*types.Log
-		for i, receipt := range receipts {
-			// Add block location fields
-			receipt.BlockHash = hash
-			receipt.BlockNumber = block.Number()
-			receipt.TransactionIndex = uint(i)
-
-			// Update the block hash in all logs since it is now available and not when the
-			// receipt/log of individual transactions were created.
-			for _, log := range receipt.Logs {
-				log.BlockHash = hash
-			}
-			logs = append(logs, receipt.Logs...)
-		}
-		_, err := v.Chain.WriteBlockAndSetHead(block, receipts, logs, state, true)
-		if err != nil {
-			return common.Hash{}, nil, err
-		}
-		targetVmHash = header.Root
-		targetGasUsed.Add(targetGasUsed, new(big.Int).SetUint64(header.GasUsed))
-	}
-	return targetVmHash, targetGasUsed, nil
-}
-
-// This goroutine synchronizes sequenced transactions from L1 SequencerInbox
-func (v *Validator) collectingLoop() {
-	defer v.Wg.Done()
-
-	abi, err := bindings.ISequencerInboxMetaData.GetAbi()
-	if err != nil {
-		log.Crit("Failed to get ISequencerInbox ABI", "err", err)
-	}
-
-	// Listen to TxBatchAppendEvent
-	batchEventCh := make(chan *bindings.ISequencerInboxTxBatchAppended, 4096)
-	batchEventSub, err := v.Inbox.Contract.WatchTxBatchAppended(&bind.WatchOpts{Context: v.Ctx}, batchEventCh)
-	if err != nil {
-		log.Crit("Failed to watch rollup event", "err", err)
-	}
-	defer batchEventSub.Unsubscribe()
-
-	for {
-		// if challenge, pause
-		select {
-		case ev := <-batchEventCh:
-			// New appendTxBatch call
-			tx, _, err := v.L1.TransactionByHash(v.Ctx, ev.Raw.TxHash)
-			if err != nil {
-				log.Error("Failed to get tx batch data", "error", err)
-				continue
-			}
-			// Decode input from abi
-			decoded, err := abi.Methods["appendTxBatch"].Inputs.Unpack(tx.Data()[4:])
-			if err != nil {
-				log.Error("Failed to decode tx batch data", "error", err)
-				continue
-			}
-			// Construct batch
-			batch, err := rollupTypes.TxBatchFromDecoded(decoded)
-			if err != nil {
-				log.Error("Failed to decode tx batch data", "error", err)
-				continue
-			}
-			v.batchCh <- batch
-		case <-v.Ctx.Done():
-			return
-		}
-	}
+	return nil
 }
 
 // This goroutine validates the assertion posted to L1 Rollup, advances
@@ -192,8 +109,6 @@ func (v *Validator) validationLoop(genesisRoot common.Hash) {
 	}
 	defer assertionEventSub.Unsubscribe()
 
-	// Sequenced blocks collected from SequencerInbox
-	var pendingBlocks []*rollupTypes.SequenceBlock
 	// Current agreed assertion, initalize to genesis assertion
 	// TODO: sync from L1 when restart
 	confirmedAssertion := &rollupTypes.Assertion{
@@ -204,31 +119,58 @@ func (v *Validator) validationLoop(genesisRoot common.Hash) {
 		Deadline:              new(big.Int),
 		PrevCumulativeGasUsed: new(big.Int),
 	}
+	// The next assertion to be validated
+	var currentAssertion *rollupTypes.Assertion
 
 	isInChallenge := false
+
+	validateCurrentAssertion := func() error {
+		// Validate current assertion
+		err := v.tryVaidateAssertion(confirmedAssertion, currentAssertion)
+		if err != nil {
+			switch {
+			case errors.Is(err, errValidationFailed):
+				// Validation failed, challenge
+				isInChallenge = true
+			case errors.Is(err, errAssertionOverflowedInbox):
+				// Assertion overflowed inbox, wait for next block
+			}
+			return err
+		}
+		// Validation success, get next pending assertion
+		confirmedAssertion = currentAssertion
+		currentAssertion = nil
+		return nil
+	}
 
 	for {
 		if isInChallenge {
 			// Wait for the challenge resolution
 			select {
-			case <-v.challengeResoutionCh:
+			case ourAssertion := <-v.challengeResoutionCh:
 				log.Info("challenge finished")
 				isInChallenge = false
+				confirmedAssertion = ourAssertion
+				currentAssertion = nil
+				// Try to validate all pending assertion
+				for currentAssertion != nil {
+					err := validateCurrentAssertion()
+					if err != nil {
+						break
+					}
+				}
 			case <-v.Ctx.Done():
 				return
 			}
 		} else {
 			select {
-			case batch := <-v.batchCh:
-				// New batch collected from SequencerInbox, split it into blocks
-				txNum := 0
-				for _, ctx := range batch.Contexts {
-					block := &rollupTypes.SequenceBlock{
-						SequenceContext: ctx,
-						Txs:             batch.Txs[txNum : txNum+int(ctx.NumTxs)],
+			case <-v.newBatchCh:
+				// New block committed, try to validate all pending assertion
+				for currentAssertion != nil {
+					err := validateCurrentAssertion()
+					if err != nil {
+						break
 					}
-					pendingBlocks = append(pendingBlocks, block)
-					txNum += int(ctx.NumTxs)
 				}
 			case ev := <-assertionEventCh:
 				if ev.AsserterAddr == common.Address(v.Config.Coinbase) {
@@ -244,49 +186,13 @@ func (v *Validator) validationLoop(genesisRoot common.Hash) {
 					StartBlock:            confirmedAssertion.EndBlock + 1,
 					PrevCumulativeGasUsed: new(big.Int).Set(confirmedAssertion.CumulativeGasUsed),
 				}
-				// Pop correct amount of pending blocks asserted
-				inboxSizeDiff := assertion.InboxSize.Uint64() - confirmedAssertion.InboxSize.Uint64()
-				var blocksToCommit []*rollupTypes.SequenceBlock
-				for _, block := range pendingBlocks {
-					if block.NumTxs > inboxSizeDiff {
-						log.Crit("UNHANDELED: Assertion created in the middle of block, validator state corrupted!")
-					}
-					inboxSizeDiff -= block.NumTxs
-					blocksToCommit = append(blocksToCommit, block)
-					if inboxSizeDiff == 0 {
-						break
-					}
+				if currentAssertion != nil {
+					// TODO: handle concurrent assertions
+					log.Crit("UNHANDELED: concurrent assertion")
+					continue
 				}
-				if inboxSizeDiff != 0 {
-					log.Crit("UNHANDELED: SequencerInbox overflow, validator state corrupted!")
-				}
-				assertion.EndBlock = assertion.StartBlock + uint64(len(blocksToCommit)) - 1
-				pendingBlocks = pendingBlocks[len(blocksToCommit):]
-				// Commit asserted blocks
-				targetVmHash, targetGasUsed, err := v.commitBlocks(blocksToCommit)
-				if err != nil {
-					// strange error, TODO: rewind
-					log.Crit("UNHANDELED: Can't execute sequence blocks, validator state corrupted", "err", err)
-				}
-				// Check result vm hash and gas
-				targetGasUsed.Add(targetGasUsed, confirmedAssertion.CumulativeGasUsed)
-				if targetVmHash != assertion.VmHash || targetGasUsed.Cmp(assertion.CumulativeGasUsed) != 0 {
-					// Validation failed
-					ourAssertion := &rollupTypes.Assertion{
-						VmHash:            targetVmHash,
-						InboxSize:         ev.InboxSize,
-						CumulativeGasUsed: targetGasUsed,
-					}
-					v.challengeCh <- &challengeCtx{assertion, ourAssertion, confirmedAssertion}
-					isInChallenge = true
-				} else {
-					// Validation succeeded, confirm assertion and advance stake
-					_, err = v.Rollup.AdvanceStake(ev.AssertionID)
-					if err != nil {
-						log.Crit("UNHANDELED: Can't advance stake, validator state corrupted", "err", err)
-					}
-					confirmedAssertion = assertion
-				}
+				currentAssertion = assertion
+				validateCurrentAssertion()
 			case <-v.Ctx.Done():
 				return
 			}
@@ -389,7 +295,7 @@ func (v *Validator) challengeLoop() {
 				challengeCompletedSub.Unsubscribe()
 				states = []*proof.ExecutionState{}
 				inChallenge = false
-				v.challengeResoutionCh <- struct{}{}
+				v.challengeResoutionCh <- ctx.ourAssertion
 			case <-v.Ctx.Done():
 				bisectedSub.Unsubscribe()
 				challengeCompletedSub.Unsubscribe()
@@ -475,10 +381,10 @@ func (v *Validator) challengeLoop() {
 }
 
 func (v *Validator) Start() error {
-	genesis := v.BaseService.Start()
+	genesis := v.BaseService.Start(true, true)
 
 	v.Wg.Add(3)
-	go v.collectingLoop()
+	go v.SyncLoop(v.newBatchCh)
 	go v.validationLoop(genesis.Root())
 	go v.challengeLoop()
 	log.Info("Validator started")

--- a/clients/geth/specular/rollup/test-node/.gitignore
+++ b/clients/geth/specular/rollup/test-node/.gitignore
@@ -1,2 +1,3 @@
 data
 data_validator
+data_indexer

--- a/clients/geth/specular/rollup/test-node/attach_indexer.sh
+++ b/clients/geth/specular/rollup/test-node/attach_indexer.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../build/bin/geth --datadir ./data attach http://localhost:4021

--- a/clients/geth/specular/rollup/test-node/clean.sh
+++ b/clients/geth/specular/rollup/test-node/clean.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 rm -rf ./data/geth
 rm -rf ./data_validator/geth
-rm -rf ./data_rogue_validator/geth
+rm -rf ./data_indexer/geth

--- a/clients/geth/specular/rollup/test-node/import_accounts.sh
+++ b/clients/geth/specular/rollup/test-node/import_accounts.sh
@@ -3,3 +3,5 @@
 ../../build/bin/geth --password ./password.txt --datadir ./data account import ./keys/validator.prv
 ../../build/bin/geth --password ./password.txt --datadir ./data_validator account import ./keys/sequencer.prv
 ../../build/bin/geth --password ./password.txt --datadir ./data_validator account import ./keys/validator.prv
+../../build/bin/geth --password ./password.txt --datadir ./data_indexer account import ./keys/sequencer.prv
+../../build/bin/geth --password ./password.txt --datadir ./data_indexer account import ./keys/validator.prv

--- a/clients/geth/specular/rollup/test-node/init.sh
+++ b/clients/geth/specular/rollup/test-node/init.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 ../../build/bin/geth --datadir ./data --networkid 13527 init ./genesis.json
 ../../build/bin/geth --datadir ./data_validator --networkid 13527 init ./genesis.json
+../../build/bin/geth --datadir ./data_indexer --networkid 13527 init ./genesis.json

--- a/clients/geth/specular/rollup/test-node/start_indexer.sh
+++ b/clients/geth/specular/rollup/test-node/start_indexer.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+../../build/bin/geth \
+    --datadir ./data_indexer \
+    --password password.txt \
+    --http --http.addr '0.0.0.0' --http.port 4021 --http.api 'personal,eth,net,web3,txpool,miner,proof,debug' \
+    --ws --ws.addr '0.0.0.0' --ws.port 4022 --ws.api 'personal,eth,net,web3,txpool,miner,proof,debug' \
+    --http.corsdomain '*' --ws.origins '*' \
+    --gcmode=archive \
+    --networkid 13527 \
+    --port 30305 \
+    --authrpc.port 8562 \
+    --rollup.node 'indexer' \
+    --rollup.coinbase=f39fd6e51aad88f6f4ce6ab8827279cfffb92266 \
+    --rollup.l1endpoint 'ws://localhost:8545' \
+    --rollup.l1chainid 31337 \
+    --rollup.sequencer-inbox-addr '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0' \
+    --rollup.rollup-addr '0x0165878A594ca255338adfa4d48449f69242Eb8F' \
+    --rollup.rollup-stake-amount 100 \
+    --rollup.l1-rollup-genesis-block 0

--- a/clients/geth/specular/rollup/test-node/start_validator.sh
+++ b/clients/geth/specular/rollup/test-node/start_validator.sh
@@ -15,4 +15,5 @@
     --rollup.sequencer-addr '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' \
     --rollup.sequencer-inbox-addr '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0' \
     --rollup.rollup-addr '0x0165878A594ca255338adfa4d48449f69242Eb8F' \
-    --rollup.rollup-stake-amount 100
+    --rollup.rollup-stake-amount 100 \
+    --rollup.l1-rollup-genesis-block 0


### PR DESCRIPTION
# Goals of PR

Dependencies:

- #11 
- #12 

Core changes:

- Refactor validator's inbox syncing, move to base service
- Validator behavior change: executes transactions when they are posted in the inbox instead of when new assertions published
- `BaseService.SyncInbox` allows a service to sync past sequenced transactions
- `BaseService.SyncLoop` allows a service to sync past sequenced transactions as well as watch ongoing ones
- `Indexer` is a service that only syncs sequenced transactions to its local blockchain, it won't participate in the validation/challenge
  - It is designed for the block explorer when used with archive flag

Notes:

- Assertion/Stake sync is not implemented in this pr so the sequencer/validator still can not be restarted
