### PR TITLE
Fix `Rollup` initialize function 

### DIFF
--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -91,7 +91,7 @@ contract Rollup is RollupBase {
         bytes32 _initialVMhash
     ) public initializer {
         // TODO: do we still need stake token now?
-        
+
         // If any of addresses _owner, _sequencerInbox or _verifier is address(0), then revert.
         if (_owner == address(0) || _sequencerInbox == address(0) || _verifier == address(0)) {
             revert ZeroAddress();

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -91,7 +91,9 @@ contract Rollup is RollupBase {
         bytes32 _initialVMhash
     ) public initializer {
         // TODO: do we still need stake token now?
-        if (_owner == address(0) && _sequencerInbox == address(0) && _verifier == address(0)) {
+        
+        // If any of addresses _owner, _sequencerInbox or _verifier is address(0), then revert.
+        if (_owner == address(0) || _sequencerInbox == address(0) || _verifier == address(0)) {
             revert ZeroAddress();
         }
         owner = _owner;


### PR DESCRIPTION
# Goals of PR

The `if` statement logic to validate input for `Rollup.initialize` has been fixed to revert for any address(0) that is supplied.

## Previously
```
        if (_owner == address(0) && _sequencerInbox == address(0) && _verifier == address(0)) {
            revert ZeroAddress();
        }
```

## Now

```
        if (_owner == address(0) ||  _sequencerInbox == address(0) || _verifier == address(0)) {
            revert ZeroAddress();
        }
```
