### PR TITLE
Fixing critical issues in Rollup contract

### DIFF
--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -177,11 +177,14 @@ contract Rollup is RollupBase {
         if (staker.assertionID > lastConfirmedAssertionID) {
             revert StakedOnUnconfirmedAssertion();
         }
-        (bool success,) = stakerAddress.call{value: staker.amountStaked}("");
-        if (!success) revert TransferFailed();
+
+        uint256 stakerAmountStaked = staker.amountStaked;
 
         // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
         deleteStaker(stakerAddress);
+
+        (bool success,) = stakerAddress.call{value: stakerAmountStaked}("");
+        if (!success) revert TransferFailed();
     }
 
     /// @inheritdoc IRollup

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -177,16 +177,17 @@ contract Rollup is RollupBase {
         if (staker.assertionID > lastConfirmedAssertionID) {
             revert StakedOnUnconfirmedAssertion();
         }
+        uint256 stakedAmount = staker.amountStaked;
         deleteStaker(stakerAddress);
         // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
-        (bool success,) = stakerAddress.call{value: staker.amountStaked}("");
+        (bool success,) = stakerAddress.call{value: stakedAmount}("");
         if (!success) revert TransferFailed();
     }
 
     /// @inheritdoc IRollup
     function advanceStake(uint256 assertionID) external override stakedOnly {
         Staker storage staker = stakers[msg.sender];
-        if (assertionID <= staker.assertionID && assertionID > lastCreatedAssertionID) {
+        if (assertionID <= staker.assertionID || assertionID > lastCreatedAssertionID) {
             revert AssertionOutOfRange();
         }
         // TODO: allow arbitrary descendant of current staked assertionID, not just child.

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -177,11 +177,11 @@ contract Rollup is RollupBase {
         if (staker.assertionID > lastConfirmedAssertionID) {
             revert StakedOnUnconfirmedAssertion();
         }
-        uint256 stakedAmount = staker.amountStaked;
-        deleteStaker(stakerAddress);
-        // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
-        (bool success,) = stakerAddress.call{value: stakedAmount}("");
+        (bool success,) = stakerAddress.call{value: staker.amountStaked}("");
         if (!success) revert TransferFailed();
+
+        // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
+        deleteStaker(stakerAddress);
     }
 
     /// @inheritdoc IRollup

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -22,6 +22,7 @@ import "forge-std/Test.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import "../src/libraries/Errors.sol";
+import {ISequencerInbox} from "../src/ISequencerInbox.sol";
 import {SequencerInbox} from "../src/SequencerInbox.sol";
 import {Utils} from "./utils/Utils.sol";
 
@@ -75,7 +76,7 @@ contract SequencerInboxTest is BaseSetup {
     }
 
     function test_RevertWhen_EmptyBatch() public {
-        vm.expectRevert(EmptyBatch.selector);
+        vm.expectRevert(ISequencerInbox.EmptyBatch.selector);
         vm.prank(sequencer);
         uint256[] memory contexts = new uint256[](1);
         uint256[] memory txLengths = new uint256[](1);


### PR DESCRIPTION
1. Rollup.removeStake function has a bug that leads to loss of funds of staker. The value transferred to the staker would always be 0.  
2. Rollup.removeStake function has a bug.
3. 
```
/**
         * function removeStake(address stakerAddress) external override {
         *             requireStaked(stakerAddress);
         *             // Require that staker is staked on a confirmed assertion.
         *             Staker storage staker = stakers[stakerAddress];
         *             if (staker.assertionID > lastConfirmedAssertionID) {
         *                 revert StakedOnUnconfirmedAssertion();
         *             }
         *             deleteStaker(stakerAddress);
         *             // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
         *             (bool success,) = stakerAddress.call{value: staker.amountStaked}("");
         *             if (!success) revert TransferFailed();
         *         }
 */
        // Now what you'll notice in the second last line where the stake is being transferred to the staker, the value is kept as `staker.amountStaked`. However in the line above that
        // the staker has been deleted and thus the value transferred will always be 0.
        // Need to fix this critical bug.
```
4. Rollup.advanceStake function has a bug that allows out-of-range assertionIDs to be passed to this function. See the below code section with comments for more explanation
5. 
```
// The following lines of test are written to expect the rollup.advanceStake function to revert with the error IRollup.AssertionOutOfRange error,
// since the assertionID is generated randomly and checked so that it does not lie between the staker's assertionID and the last createdID.
// However, the test fails to revert since the function uses an `&&` operator to check these conditions rather than an `||` operator.
// Commenting out this test unless the bug in the Rollup contract is not fixed.
/**
    function advanceStake(uint256 assertionID) external override stakedOnly {
        Staker storage staker = stakers[msg.sender];
        // The below line has the bug.
        if (assertionID <= staker.assertionID && assertionID > lastCreatedAssertionID) {
            revert AssertionOutOfRange();
        }
        // TODO: allow arbitrary descendant of current staked assertionID, not just child.
        if (staker.assertionID != assertions.getParentID(assertionID)) {
            revert ParentAssertionUnstaked();
        }
        stakeOnAssertion(msg.sender, assertionID);
    }
 */

// vm.expectRevert(IRollup.AssertionOutOfRange.selector);
// vm.prank(alice);

// rollup.advanceStake(assertionID);
```