### PR TITLE
handle low-l1 eth errors

### DIFF
--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -230,6 +230,9 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 			confirmedAssertion.VmHash,
 			confirmedAssertion.CumulativeGasUsed,
 		)
+		if err.Is(err, core.ErrInsufficientFunds) {
+			log.Crit("Insufficient Funds to send Tx", "error", err)
+		}		
 		if err != nil {
 			log.Error("Can not create DA", "error", err)
 		}
@@ -251,6 +254,9 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 				continue
 			}
 			_, err = s.Inbox.AppendTxBatch(contexts, txLengths, txs)
+			if err.Is(err, core.ErrInsufficientFunds) {
+				log.Crit("Insufficient Funds to send Tx", "error", err)
+			}
 			if err != nil {
 				log.Error("Can not sequence batch", "error", err)
 				continue
@@ -357,6 +363,9 @@ func (s *Sequencer) confirmationLoop() {
 					if header.Number.Uint64() >= pendingAssertion.Deadline.Uint64() {
 						// Confirmation period has past, confirm it
 						_, err := s.Rollup.ConfirmFirstUnresolvedAssertion()
+						if err.Is(err, core.ErrInsufficientFunds) {
+							log.Crit("Insufficient Funds to send Tx", "error", err)
+						}
 						if err != nil {
 							// log.Error("Failed to confirm DA", "error", err)
 							log.Crit("Failed to confirm DA", "err", err)

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -90,6 +90,9 @@ func (v *Validator) tryValidateAssertion(lastValidatedAssertion, assertion *roll
 	}
 	// Validation succeeded, confirm assertion and advance stake
 	_, err := v.Rollup.AdvanceStake(assertion.ID)
+	if err.Is(err, core.ErrInsufficientFunds) {
+		log.Crit("Insufficient Funds to send Tx", "error", err)
+	}	
 	if err != nil {
 		log.Crit("UNHANDELED: Can't advance stake, validator state corrupted", "err", err)
 	}
@@ -313,6 +316,9 @@ func (v *Validator) challengeLoop() {
 					ctx.lastValidatedAssertion.VmHash,
 					ctx.lastValidatedAssertion.CumulativeGasUsed,
 				)
+				if err.Is(err, core.ErrInsufficientFunds) {
+					log.Crit("Insufficient Funds to send Tx", "error", err)
+				}	
 				if err != nil {
 					log.Crit("UNHANDELED: Can't create assertion for challenge, validator state corrupted", "err", err)
 				}
@@ -329,6 +335,9 @@ func (v *Validator) challengeLoop() {
 								ev.AssertionID,
 							},
 						)
+						if err.Is(err, core.ErrInsufficientFunds) {
+							log.Crit("Insufficient Funds to send Tx", "error", err)
+						}	
 						if err != nil {
 							log.Crit("UNHANDELED: Can't start challenge, validator state corrupted", "err", err)
 						}


### PR DESCRIPTION
This PR handles the errors whenever the sequencer can't send a transaction because of insufficient funds.