### PR TITLE
Handle low l1 eth - fix typo in #32

### DIFF
--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -1,6 +1,7 @@
 package sequencer
 
 import (
+	errors "errors"
 	"math/big"
 	"time"
 
@@ -230,7 +231,7 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 			confirmedAssertion.VmHash,
 			confirmedAssertion.CumulativeGasUsed,
 		)
-		if err.Is(err, core.ErrInsufficientFunds) {
+		if errors.Is(err, core.ErrInsufficientFunds) {
 			log.Crit("Insufficient Funds to send Tx", "error", err)
 		}		
 		if err != nil {
@@ -254,7 +255,7 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 				continue
 			}
 			_, err = s.Inbox.AppendTxBatch(contexts, txLengths, txs)
-			if err.Is(err, core.ErrInsufficientFunds) {
+			if errors.Is(err, core.ErrInsufficientFunds) {
 				log.Crit("Insufficient Funds to send Tx", "error", err)
 			}
 			if err != nil {
@@ -363,7 +364,7 @@ func (s *Sequencer) confirmationLoop() {
 					if header.Number.Uint64() >= pendingAssertion.Deadline.Uint64() {
 						// Confirmation period has past, confirm it
 						_, err := s.Rollup.ConfirmFirstUnresolvedAssertion()
-						if err.Is(err, core.ErrInsufficientFunds) {
+						if errors.Is(err, core.ErrInsufficientFunds) {
 							log.Crit("Insufficient Funds to send Tx", "error", err)
 						}
 						if err != nil {

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -230,6 +230,9 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 			confirmedAssertion.VmHash,
 			confirmedAssertion.CumulativeGasUsed,
 		)
+		if err.Is(err, core.ErrInsufficientFunds) {
+			log.Crit("Insufficient Funds to send Tx", "error", err)
+		}		
 		if err != nil {
 			log.Error("Can not create DA", "error", err)
 		}
@@ -251,6 +254,9 @@ func (s *Sequencer) sequencingLoop(genesisRoot common.Hash) {
 				continue
 			}
 			_, err = s.Inbox.AppendTxBatch(contexts, txLengths, txs)
+			if err.Is(err, core.ErrInsufficientFunds) {
+				log.Crit("Insufficient Funds to send Tx", "error", err)
+			}
 			if err != nil {
 				log.Error("Can not sequence batch", "error", err)
 				continue
@@ -357,6 +363,9 @@ func (s *Sequencer) confirmationLoop() {
 					if header.Number.Uint64() >= pendingAssertion.Deadline.Uint64() {
 						// Confirmation period has past, confirm it
 						_, err := s.Rollup.ConfirmFirstUnresolvedAssertion()
+						if err.Is(err, core.ErrInsufficientFunds) {
+							log.Crit("Insufficient Funds to send Tx", "error", err)
+						}
 						if err != nil {
 							// log.Error("Failed to confirm DA", "error", err)
 							log.Crit("Failed to confirm DA", "err", err)

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -90,6 +90,9 @@ func (v *Validator) tryValidateAssertion(lastValidatedAssertion, assertion *roll
 	}
 	// Validation succeeded, confirm assertion and advance stake
 	_, err := v.Rollup.AdvanceStake(assertion.ID)
+	if err.Is(err, core.ErrInsufficientFunds) {
+		log.Crit("Insufficient Funds to send Tx", "error", err)
+	}	
 	if err != nil {
 		log.Crit("UNHANDELED: Can't advance stake, validator state corrupted", "err", err)
 	}
@@ -313,6 +316,9 @@ func (v *Validator) challengeLoop() {
 					ctx.lastValidatedAssertion.VmHash,
 					ctx.lastValidatedAssertion.CumulativeGasUsed,
 				)
+				if err.Is(err, core.ErrInsufficientFunds) {
+					log.Crit("Insufficient Funds to send Tx", "error", err)
+				}	
 				if err != nil {
 					log.Crit("UNHANDELED: Can't create assertion for challenge, validator state corrupted", "err", err)
 				}
@@ -329,6 +335,9 @@ func (v *Validator) challengeLoop() {
 								ev.AssertionID,
 							},
 						)
+						if err.Is(err, core.ErrInsufficientFunds) {
+							log.Crit("Insufficient Funds to send Tx", "error", err)
+						}	
 						if err != nil {
 							log.Crit("UNHANDELED: Can't start challenge, validator state corrupted", "err", err)
 						}

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -90,7 +91,7 @@ func (v *Validator) tryValidateAssertion(lastValidatedAssertion, assertion *roll
 	}
 	// Validation succeeded, confirm assertion and advance stake
 	_, err := v.Rollup.AdvanceStake(assertion.ID)
-	if err.Is(err, core.ErrInsufficientFunds) {
+	if errors.Is(err, core.ErrInsufficientFunds) {
 		log.Crit("Insufficient Funds to send Tx", "error", err)
 	}	
 	if err != nil {
@@ -316,7 +317,7 @@ func (v *Validator) challengeLoop() {
 					ctx.lastValidatedAssertion.VmHash,
 					ctx.lastValidatedAssertion.CumulativeGasUsed,
 				)
-				if err.Is(err, core.ErrInsufficientFunds) {
+				if errors.Is(err, core.ErrInsufficientFunds) {
 					log.Crit("Insufficient Funds to send Tx", "error", err)
 				}	
 				if err != nil {
@@ -335,7 +336,7 @@ func (v *Validator) challengeLoop() {
 								ev.AssertionID,
 							},
 						)
-						if err.Is(err, core.ErrInsufficientFunds) {
+						if errors.Is(err, core.ErrInsufficientFunds) {
 							log.Crit("Insufficient Funds to send Tx", "error", err)
 						}	
 						if err != nil {


### PR DESCRIPTION

Fixes a typo in sequencer and validator `errors.Is` 