### PR TITLE
Fix slither workflow dubious ownership issue (temporary patch)

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.2.0
+        uses: crytic/slither-action@dev-git-safe-workspace
         id: slither
         with:
           sarif: results.sarif


### PR DESCRIPTION
Fixing the `fatal: detected dubious ownership in repository at '/github/workspace'` issue using  [dev-git-safe-workspace](https://github.com/crytic/slither-action/issues/49) branch from slither-action.