### PR TITLE
Fix rollup proxy deployment

### DIFF
--- a/contracts/deploy/02_deploy_Rollup.ts
+++ b/contracts/deploy/02_deploy_Rollup.ts
@@ -4,20 +4,19 @@ import { Manifest } from "@openzeppelin/upgrades-core";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, ethers, upgrades, network } = hre;
-  const { deploy } = deployments;
-  const { sequencer } = await getNamedAccounts();
+  const { save } = deployments;
+  const { sequencer, deployer } = await getNamedAccounts();
+  const deployerSigner = await ethers.getSigner(deployer);
   const { provider } = network;
-  const manifest = await Manifest.forNetwork(provider);
 
-  const proxies = (await manifest.read()).proxies;
-
-  const sequencerInboxProxy = proxies[0];
-  const verifierProxy = proxies[1];
+  const sequencerInboxProxyAddress = (await deployments.get("SequencerInbox"))
+    .address;
+  const verifierProxyAddress = (await deployments.get("Verifier")).address;
 
   const rollupArgs = [
     sequencer, // address _vault
-    sequencerInboxProxy.address, // address _sequencerInbox
-    verifierProxy.address, // address _verifier
+    sequencerInboxProxyAddress, // address _sequencerInbox
+    verifierProxyAddress, // address _verifier
     "0x0000000000000000000000000000000000000000", // address _stakeToken
     5, // uint256 _confirmationPeriod
     0, // uint256 _challengePeriod
@@ -27,7 +26,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     "0x744c19d2e8593c97867b3b6a3588f51cd9dbc5010a395cf199be4bbb353848b8", // bytes32 _initialVMhash
   ];
 
-  const Rollup = await ethers.getContractFactory("Rollup");
+  const Rollup = await ethers.getContractFactory("Rollup", deployer);
   const rollup = await upgrades.deployProxy(Rollup, rollupArgs, {
     initializer: "initialize",
     from: sequencer,
@@ -45,6 +44,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     "Rollup Admin Address",
     await upgrades.erc1967.getAdminAddress(rollup.address)
   );
+
+  const artifact = await deployments.getExtendedArtifact("Rollup");
+  const proxyDeployments = {
+    address: rollup.address,
+    ...artifact,
+  };
+  await save("Rollup", proxyDeployments);
 };
 
 export default func;

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -76,6 +76,7 @@ const config: HardhatUserConfig = {
       chiado: SEQUENCER_ADDRESS,
     },
     validator: 1,
+    deployer: 2,
   },
   networks: {
     mainnet: createConfig("mainnet"),


### PR DESCRIPTION
# Goals of PR

Core changes:

- Use deployment file instead of upgrade manifest to determine previously deployed proxy addresses.

Notes:

- During deployment the `proxies` array of upgrade manifest will be updated out of order if it is not a fresh deployment, causing mismatching of initialize arguments of rollup contract.
