### PR TITLE
bump slither-action to v0.3.0

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run Slither
-        uses: crytic/slither-action@dev-git-safe-workspace
+        uses: crytic/slither-action@v0.3.0
         id: slither
         with:
           sarif: results.sarif


### PR DESCRIPTION
Bumping the slither action version to v0.3.0 as the temporary patch got merged in this new version. https://github.com/crytic/slither-action/releases/tag/v0.3.0 