### PR TITLE
remove unnecessary code from deployment scripts

### DIFF
--- a/contracts/deploy/00_deploy_SequencerInbox.ts
+++ b/contracts/deploy/00_deploy_SequencerInbox.ts
@@ -10,7 +10,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Inbox = await ethers.getContractFactory("SequencerInbox", deployer);
   const inbox = await upgrades.deployProxy(Inbox, [sequencer], {
     initializer: "initialize",
-    from: sequencer,
     timeout: 0,
     kind: "uups",
   });

--- a/contracts/deploy/01_deploy_Verifier.ts
+++ b/contracts/deploy/01_deploy_Verifier.ts
@@ -10,7 +10,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Verifier = await ethers.getContractFactory("Verifier", deployer);
   const verifier = await upgrades.deployProxy(Verifier, [], {
     initializer: "initialize",
-    from: sequencer,
     timeout: 0,
     kind: "uups",
   });

--- a/contracts/deploy/02_deploy_Rollup.ts
+++ b/contracts/deploy/02_deploy_Rollup.ts
@@ -29,7 +29,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Rollup = await ethers.getContractFactory("Rollup", deployer);
   const rollup = await upgrades.deployProxy(Rollup, rollupArgs, {
     initializer: "initialize",
-    from: sequencer,
     timeout: 0,
     kind: "uups",
   });


### PR DESCRIPTION
removing `from` option from `deployProxy` in all deployment scripts