### PR TITLE
Add Assertion Rejection to sequencer

### DIFF
--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -26,8 +26,8 @@ type challengeCtx struct {
 	lastValidatedAssertion *rollupTypes.Assertion
 }
 
-var errAssertionOverflowedLocalInbox = fmt.Errorf("[Validator] assertion overflowed inbox")
-var errValidationFailed = fmt.Errorf("[Validator] validation failed")
+var errAssertionOverflowedLocalInbox = fmt.Errorf("assertion overflowed inbox")
+var errValidationFailed = fmt.Errorf("validation failed")
 
 type Validator struct {
 	*services.BaseService


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add Assertion Rejection to the sequencer

Notes:

- RejectFirstUnresolvedAssertion(s.Config.SequencerAddr) is called for Sequencer's Address as the sequencer creates all assertions and on creating an assertion it also stakes on assertion. (In Rollup.sol: createAssertion -> stakeOnAssertion -> StakerStaked)
