### PR TITLE
Custom Error Added

### DIFF
--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -5,7 +5,6 @@ import (
 	errors "errors"
 	"math/big"
 	"time"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -19,6 +18,7 @@ import (
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services"
 	rollupTypes "github.com/specularl2/specular/clients/geth/specular/rollup/types"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/log"
+	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/fmt"
 )
 
 

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -18,6 +17,7 @@ import (
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services"
 	rollupTypes "github.com/specularl2/specular/clients/geth/specular/rollup/types"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/log"
+	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/fmt"
 )
 
 type challengeCtx struct {
@@ -140,7 +140,7 @@ func (v *Validator) validationLoop(ctx context.Context) {
 				log.Warn("Assertion overflowed local inbox, wait for next batch event", "expected size", currentAssertion.InboxSize)
 				return nil
 			default:
-				return err
+				return fmt.Errorf("tryValidateAssertion Failed",err)
 			}
 		}
 		// Validation success, clean up

--- a/clients/geth/specular/rollup/utils/errors/error.go
+++ b/clients/geth/specular/rollup/utils/errors/error.go
@@ -1,0 +1,138 @@
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"runtime"
+)
+
+// The maximum number of stackframes on any error.
+var MaxStackDepth = 50
+
+// Error is an error with an attached stacktrace. It can be used
+// wherever the builtin error interface is expected.
+type Error struct {
+	Err    error
+	stack  []uintptr
+	frames []StackFrame
+	prefix string
+}
+
+// New makes an Error from the given value. If that value is already an
+// error then it will be used directly, if not, it will be passed to
+// fmt.Errorf("%v"). The stacktrace will point to the line of code that
+// called New.
+func New(e interface{}) *Error {
+	var err error
+
+	switch e := e.(type) {
+	case error:
+		err = e
+	default:
+		err = fmt.Errorf("%v", e)
+	}
+
+	stack := make([]uintptr, MaxStackDepth)
+	length := runtime.Callers(2, stack[:])
+	return &Error{
+		Err:   err,
+		stack: stack[:length],
+	}
+}
+
+// Wrap makes an Error from the given value. If that value is already an
+// error then it will be used directly, if not, it will be passed to
+// fmt.Errorf("%v"). The skip parameter indicates how far up the stack
+// to start the stacktrace. 0 is from the current call, 1 from its caller, etc.
+func Wrap(e interface{}, skip int) *Error {
+	if e == nil {
+		return nil
+	}
+
+	var err error
+
+	switch e := e.(type) {
+	case *Error:
+		return e
+	case error:
+		err = e
+	default:
+		err = fmt.Errorf("%v", e)
+	}
+
+	stack := make([]uintptr, MaxStackDepth)
+	length := runtime.Callers(2+skip, stack[:])
+	return &Error{
+		Err:   err,
+		stack: stack[:length],
+	}
+}
+
+
+// Errorf creates a new error with the given message. You can use it
+// as a drop-in replacement for fmt.Errorf() to provide descriptive
+// errors in return values.
+func Errorf(format string, a ...interface{}) *Error {
+	return Wrap(fmt.Errorf(format, a...), 1)
+}
+
+// Error returns the underlying error's message.
+func (err *Error) Error() string {
+
+	msg := err.Err.Error()
+	if err.prefix != "" {
+		msg = fmt.Sprintf("%s: %s", err.prefix, msg)
+	}
+
+	return msg
+}
+
+// Stack returns the callstack formatted the same way that go does
+// in runtime/debug.Stack()
+func (err *Error) Stack() []byte {
+	buf := bytes.Buffer{}
+	frame :=  err.StackFrames()[0] 
+	buf.WriteString(frame.String())
+	return buf.Bytes()
+}
+
+// Callers satisfies the bugsnag ErrorWithCallerS() interface
+// so that the stack can be read out.
+func (err *Error) Callers() []uintptr {
+	return err.stack
+}
+
+// ErrorStack returns a string that contains both the
+// error message and the callstack.
+func (err *Error) ErrorStack() string {
+	return err.TypeName() + " " + err.Error() + "\n" + string(err.Stack())
+}
+
+
+// StackFrames returns an array of frames containing information about the
+// stack.
+func (err *Error) StackFrames() []StackFrame {
+	if err.frames == nil {
+		err.frames = make([]StackFrame, len(err.stack))
+
+		for i, pc := range err.stack {
+			err.frames[i] = NewStackFrame(pc)
+		}
+	}
+
+	return err.frames
+}
+
+// TypeName returns the type this error. e.g. *errors.stringError.
+func (err *Error) TypeName() string {
+	if _, ok := err.Err.(uncaughtPanic); ok {
+		return "panic"
+	}
+	return reflect.TypeOf(err.Err).String()
+}
+
+// Return the wrapped error (implements api for As function).
+func (err *Error) Unwrap() error {
+	return err.Err
+}

--- a/clients/geth/specular/rollup/utils/errors/parse_panic.go
+++ b/clients/geth/specular/rollup/utils/errors/parse_panic.go
@@ -1,0 +1,127 @@
+package errors
+
+import (
+	"strconv"
+	"strings"
+)
+
+type uncaughtPanic struct{ message string }
+
+func (p uncaughtPanic) Error() string {
+	return p.message
+}
+
+// ParsePanic allows you to get an error object from the output of a go program
+// that panicked. This is particularly useful with https://github.com/mitchellh/panicwrap.
+func ParsePanic(text string) (*Error, error) {
+	lines := strings.Split(text, "\n")
+
+	state := "start"
+
+	var message string
+	var stack []StackFrame
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		if state == "start" {
+			if strings.HasPrefix(line, "panic: ") {
+				message = strings.TrimPrefix(line, "panic: ")
+				state = "seek"
+			} else {
+				return nil, Errorf("bugsnag.panicParser: Invalid line (no prefix): %s", line)
+			}
+
+		} else if state == "seek" {
+			if strings.HasPrefix(line, "goroutine ") && strings.HasSuffix(line, "[running]:") {
+				state = "parsing"
+			}
+
+		} else if state == "parsing" {
+			if line == "" {
+				state = "done"
+				break
+			}
+			createdBy := false
+			if strings.HasPrefix(line, "created by ") {
+				line = strings.TrimPrefix(line, "created by ")
+				createdBy = true
+			}
+
+			i++
+
+			if i >= len(lines) {
+				return nil, Errorf("bugsnag.panicParser: Invalid line (unpaired): %s", line)
+			}
+
+			frame, err := parsePanicFrame(line, lines[i], createdBy)
+			if err != nil {
+				return nil, err
+			}
+
+			stack = append(stack, *frame)
+			if createdBy {
+				state = "done"
+				break
+			}
+		}
+	}
+
+	if state == "done" || state == "parsing" {
+		return &Error{Err: uncaughtPanic{message}, frames: stack}, nil
+	}
+	return nil, Errorf("could not parse panic: %v", text)
+}
+
+// The lines we're passing look like this:
+//
+//     main.(*foo).destruct(0xc208067e98)
+//             /0/go/src/github.com/bugsnag/bugsnag-go/pan/main.go:22 +0x151
+func parsePanicFrame(name string, line string, createdBy bool) (*StackFrame, error) {
+	idx := strings.LastIndex(name, "(")
+	if idx == -1 && !createdBy {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no call): %s", name)
+	}
+	if idx != -1 {
+		name = name[:idx]
+	}
+	pkg := ""
+
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+
+	if !strings.HasPrefix(line, "\t") {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no tab): %s", line)
+	}
+
+	idx = strings.LastIndex(line, ":")
+	if idx == -1 {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (no line number): %s", line)
+	}
+	file := line[1:idx]
+
+	number := line[idx+1:]
+	if idx = strings.Index(number, " +"); idx > -1 {
+		number = number[:idx]
+	}
+
+	lno, err := strconv.ParseInt(number, 10, 32)
+	if err != nil {
+		return nil, Errorf("bugsnag.panicParser: Invalid line (bad line number): %s", line)
+	}
+
+	return &StackFrame{
+		File:       file,
+		LineNumber: int(lno),
+		Package:    pkg,
+		Name:       name,
+	}, nil
+}

--- a/clients/geth/specular/rollup/utils/errors/stackframe.go
+++ b/clients/geth/specular/rollup/utils/errors/stackframe.go
@@ -1,0 +1,122 @@
+package errors
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// A StackFrame contains all necessary information about to generate a line
+// in a callstack.
+type StackFrame struct {
+	// The path to the file containing this ProgramCounter
+	File string
+	// The LineNumber in that file
+	LineNumber int
+	// The Name of the function that contains this ProgramCounter
+	Name string
+	// The Package that contains this function
+	Package string
+	// The underlying ProgramCounter
+	ProgramCounter uintptr
+}
+
+// NewStackFrame popoulates a stack frame object from the program counter.
+func NewStackFrame(pc uintptr) (frame StackFrame) {
+
+	frame = StackFrame{ProgramCounter: pc}
+	if frame.Func() == nil {
+		return
+	}
+	frame.Package, frame.Name = packageAndName(frame.Func())
+
+	// pc -1 because the program counters we use are usually return addresses,
+	// and we want to show the line that corresponds to the function call
+	frame.File, frame.LineNumber = frame.Func().FileLine(pc - 1)
+	return
+
+}
+
+// Func returns the function that contained this frame.
+func (frame *StackFrame) Func() *runtime.Func {
+	if frame.ProgramCounter == 0 {
+		return nil
+	}
+	return runtime.FuncForPC(frame.ProgramCounter)
+}
+
+// String returns the stackframe formatted in the same way as go does
+// in runtime/debug.Stack()
+func (frame *StackFrame) String() string {
+	str := fmt.Sprintf("%s:%d (0x%x)\n", frame.File, frame.LineNumber, frame.ProgramCounter)
+
+	source, err := frame.sourceLine()
+	if err != nil {
+		return str
+	}
+
+	return str + fmt.Sprintf("\t%s: %s\n", frame.Name, source)
+}
+
+// SourceLine gets the line of code (from File and Line) of the original source if possible.
+func (frame *StackFrame) SourceLine() (string, error) {
+	source, err := frame.sourceLine()
+	if err != nil {
+		return source, New(err)
+	}
+	return source, err
+}
+
+func (frame *StackFrame) sourceLine() (string, error) {
+	if frame.LineNumber <= 0 {
+		return "???", nil
+	}
+
+	file, err := os.Open(frame.File)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	currentLine := 1
+	for scanner.Scan() {
+		if currentLine == frame.LineNumber {
+			return string(bytes.Trim(scanner.Bytes(), " \t")), nil
+		}
+		currentLine++
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "???", nil
+}
+
+func packageAndName(fn *runtime.Func) (string, string) {
+	name := fn.Name()
+	pkg := ""
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//  runtime/debug.*T·ptrmethod
+	// and want
+	//  *T.ptrmethod
+	// Since the package path might contains dots (e.g. code.google.com/...),
+	// we first remove the path prefix if there is one.
+	if lastslash := strings.LastIndex(name, "/"); lastslash >= 0 {
+		pkg += name[:lastslash] + "/"
+		name = name[lastslash+1:]
+	}
+	if period := strings.Index(name, "."); period >= 0 {
+		pkg += name[:period]
+		name = name[period+1:]
+	}
+
+	name = strings.Replace(name, "·", ".", -1)
+	return pkg, name
+}

--- a/clients/geth/specular/rollup/utils/fmt/fmt.go
+++ b/clients/geth/specular/rollup/utils/fmt/fmt.go
@@ -3,28 +3,26 @@ package fmt
 import (
 	"fmt"
 	"runtime"
-
+	
 	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/errors"
 )
 
-type Error struct {
+type wrapError struct {
 	err  *errors.Error
-	file string
-	line int
-	fn   *runtime.Func
+	msg string
 }
 
-func Errorf(format string, args ...interface{}) *Error {
-	pc, file, line, _ := runtime.Caller(1)
+func Errorf(format string, args ...interface{}) *wrapError {
+	pc, _, line, _ := runtime.Caller(1)
 	fn := runtime.FuncForPC(pc)
-	return &Error{
-		err:  errors.Errorf(format, args...),
-		file: file,
-		line: line,
-		fn:   fn,
+	err := errors.Errorf(format, args...)
+	return &wrapError{
+		err:  err,
+		msg: fmt.Sprintf("%s | %s:%d", err.ErrorStack(), fn.Name(), line),
 	}
 }
 
-func (e *Error) Error() string {
-	return fmt.Sprintf("%s | %s:%d (%s)", e.err.ErrorStack(), e.file, e.line, e.fn.Name())
+func (e *wrapError) Error() string {
+	return e.msg
 }
+

--- a/clients/geth/specular/rollup/utils/fmt/fmt.go
+++ b/clients/geth/specular/rollup/utils/fmt/fmt.go
@@ -1,0 +1,30 @@
+package fmt
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/specularl2/specular/clients/geth/specular/rollup/utils/errors"
+)
+
+type Error struct {
+	err  *errors.Error
+	file string
+	line int
+	fn   *runtime.Func
+}
+
+func Errorf(format string, args ...interface{}) *Error {
+	pc, file, line, _ := runtime.Caller(1)
+	fn := runtime.FuncForPC(pc)
+	return &Error{
+		err:  errors.Errorf(format, args...),
+		file: file,
+		line: line,
+		fn:   fn,
+	}
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s | %s:%d (%s)", e.err.ErrorStack(), e.file, e.line, e.fn.Name())
+}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Old [PR 39](https://github.com/SpecularL2/specular/pull/39)
- Error returned upstream
- Fetching function name from runtime 

For a function with main calling a, a calling b & b calling c [main()->a->b->c] Error Logs generated are as follows:

```
main:11 | in main%!(EXTRA string=err, *fmt.wrapError=*fmt.wrapError assertion failed: *fmt.wrapError assertion failed: *errors.errorString assertion failed
/Users/ayush/hello/utils/fmt/fmt.go:18 (0x1007a132c)
        Errorf: err := errors.Errorf(format, args...)
 | main.c:32
/Users/ayush/hello/utils/fmt/fmt.go:18 (0x1007a132c)
        Errorf: err := errors.Errorf(format, args...)
 | main.b:26
/Users/ayush/hello/utils/fmt/fmt.go:18 (0x1007a132c)
        Errorf: err := errors.Errorf(format, args...)
 | main.a:18)0[0/0]0x02exit status 1
```
