### PR TITLE
Setters and tests for parameters in RollupBase

### DIFF
--- a/contracts/src/IRollup.sol
+++ b/contracts/src/IRollup.sol
@@ -33,6 +33,8 @@ interface IRollup {
 
     event StakerStaked(address stakerAddr, uint256 assertionID);
 
+    event ConfigurationChanged();
+
     // TODO: Include errors thrown in function documentation.
 
     /// @dev Thrown when assertion creation requested with invalid inbox size.
@@ -114,6 +116,9 @@ interface IRollup {
 
     /// @dev Thrown when there are zero stakers
     error NoStaker();
+
+    /// @dev Thrown when the staker amount is set to be increased
+    error IncreaseStake();
 
     struct Staker {
         bool isStaked;
@@ -237,4 +242,32 @@ interface IRollup {
      * assertion is not the last confirmed assertion.
      */
     function rejectFirstUnresolvedAssertion(address stakerAddress) external;
+
+    /**
+     * @notice Sets the confirmation period
+     * @param newPeriod New confirmation period
+     *
+     */
+    function setConfirmationPeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets the challenge period
+     * @param newPeriod New challenge period
+     *
+     */
+    function setChallengePeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets the minimum assertion period
+     * @param newPeriod New minimum assertion period
+     *
+     */
+    function setMinimumAssertionPeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets the base stake amount
+     * @param newAmount New base stake amount, this can only be decreased
+     *
+     */
+    function setBaseStakeAmount(uint256 newAmount) external;
 }

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -50,8 +50,6 @@ abstract contract RollupBase is
     IDAProvider public daProvider;
     IVerifier public verifier;
 
-    event ConfigurationChanged();
-
     struct AssertionState {
         mapping(address => bool) stakers; // all stakers that have ever staked on this assertion.
         mapping(bytes32 => bool) childStateHashes; // child assertion vm hashes
@@ -67,24 +65,28 @@ abstract contract RollupBase is
         __UUPSUpgradeable_init();
     }
 
+    /// @inheritdoc IRollup
     function setConfirmationPeriod(uint256 newPeriod) public onlyOwner {
         confirmationPeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
+    /// @inheritdoc IRollup
     function setChallengePeriod(uint256 newPeriod) public onlyOwner {
         challengePeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
+    /// @inheritdoc IRollup
     function setMinimumAssertionPeriod(uint256 newPeriod) public onlyOwner {
         minimumAssertionPeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
+    /// @inheritdoc IRollup
     function setBaseStakeAmount(uint256 newAmount) public onlyOwner {
         if (newAmount > baseStakeAmount) {
-            revert("Cannot increase base stake amount");
+            revert IncreaseStake();
         }
 
         baseStakeAmount = newAmount;

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -71,6 +71,25 @@ abstract contract RollupBase is
         confirmationPeriod = newPeriod;
         emit ConfigurationChanged();
     }
+
+    function setChallengePeriod(uint256 newPeriod) public onlyOwner {
+        challengePeriod = newPeriod;
+        emit ConfigurationChanged();
+    }
+
+    function setMinimumAssertionPeriod(uint256 newPeriod) public onlyOwner {
+        minimumAssertionPeriod = newPeriod;
+        emit ConfigurationChanged();
+    }
+
+    function setBaseStakeAmount(uint256 newAmount) public onlyOwner {
+        if (newAmount > baseStakeAmount) {
+            revert("Cannot increase base stake amount");
+        }
+
+        baseStakeAmount = newAmount;
+        emit ConfigurationChanged();
+    }
 }
 
 contract Rollup is RollupBase {

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -50,6 +50,8 @@ abstract contract RollupBase is
     IDAProvider public daProvider;
     IVerifier public verifier;
 
+    event ConfigurationChanged();
+
     struct AssertionState {
         mapping(address => bool) stakers; // all stakers that have ever staked on this assertion.
         mapping(bytes32 => bool) childStateHashes; // child assertion vm hashes
@@ -63,6 +65,11 @@ abstract contract RollupBase is
     function __RollupBase_init() internal onlyInitializing {
         __Ownable_init();
         __UUPSUpgradeable_init();
+    }
+
+    function setConfirmationPeriod(uint256 newPeriod) public onlyOwner {
+        confirmationPeriod = newPeriod;
+        emit ConfigurationChanged();
     }
 }
 

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -66,25 +66,25 @@ abstract contract RollupBase is
     }
 
     /// @inheritdoc IRollup
-    function setConfirmationPeriod(uint256 newPeriod) public onlyOwner {
+    function setConfirmationPeriod(uint256 newPeriod) public override onlyOwner {
         confirmationPeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
     /// @inheritdoc IRollup
-    function setChallengePeriod(uint256 newPeriod) public onlyOwner {
+    function setChallengePeriod(uint256 newPeriod) public override onlyOwner {
         challengePeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
     /// @inheritdoc IRollup
-    function setMinimumAssertionPeriod(uint256 newPeriod) public onlyOwner {
+    function setMinimumAssertionPeriod(uint256 newPeriod) override public onlyOwner {
         minimumAssertionPeriod = newPeriod;
         emit ConfigurationChanged();
     }
 
     /// @inheritdoc IRollup
-    function setBaseStakeAmount(uint256 newAmount) public onlyOwner {
+    function setBaseStakeAmount(uint256 newAmount) public override onlyOwner {
         if (newAmount > baseStakeAmount) {
             revert IncreaseStake();
         }

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -78,7 +78,7 @@ abstract contract RollupBase is
     }
 
     /// @inheritdoc IRollup
-    function setMinimumAssertionPeriod(uint256 newPeriod) override public onlyOwner {
+    function setMinimumAssertionPeriod(uint256 newPeriod) public override onlyOwner {
         minimumAssertionPeriod = newPeriod;
         emit ConfigurationChanged();
     }

--- a/contracts/test/RollUp.t.sol
+++ b/contracts/test/RollUp.t.sol
@@ -66,10 +66,7 @@ contract RollupTest is RollupBaseSetup {
         RollupBaseSetup.setUp();
 
         // Deploying the SequencerInbox
-        bytes memory seqInInitData = abi.encodeWithSignature(
-            "initialize(address)",
-            sequencerAddress
-        );
+        bytes memory seqInInitData = abi.encodeWithSignature("initialize(address)", sequencerAddress);
         vm.startPrank(deployer);
         implementationSequencer = new SequencerInbox();
         seqIn = SequencerInbox(

--- a/contracts/test/RollUp.t.sol
+++ b/contracts/test/RollUp.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Modifications Copyright 2022, Specular contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../src/ISequencerInbox.sol";
+import "../src/libraries/Errors.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Utils} from "./utils/Utils.sol";
+import {IRollup} from "../src/IRollup.sol";
+import {Verifier} from "../src/challenge/verifier/Verifier.sol";
+import {Rollup} from "../src/Rollup.sol";
+import {SequencerInbox} from "../src/SequencerInbox.sol";
+import {RLPEncodedTransactionsUtil} from "./utils/RLPEncodedTransactions.sol";
+
+contract RollupBaseSetup is Test, RLPEncodedTransactionsUtil {
+    Utils internal utils;
+    address payable[] internal users;
+
+    address internal alice;
+    address internal bob;
+    address internal deployer;
+    address internal sequencerAddress;
+
+    event ConfigurationChanged();
+
+    Verifier verifier = new Verifier();
+
+    function setUp() public virtual {
+        utils = new Utils();
+        users = utils.createUsers(4);
+
+        alice = users[0];
+        bob = users[1];
+        deployer = users[2];
+        sequencerAddress = users[3];
+    }
+}
+
+contract RollupTest is RollupBaseSetup {
+    Rollup public rollup;
+    uint256 randomNonce;
+    SequencerInbox public seqIn;
+    SequencerInbox public implementationSequencer;
+
+    function setUp() public virtual override {
+        // Parent contract setup
+        RollupBaseSetup.setUp();
+
+        // Deploying the SequencerInbox
+        bytes memory seqInInitData = abi.encodeWithSignature("initialize(address)", sequencerAddress);
+        vm.startPrank(deployer);
+        implementationSequencer = new SequencerInbox();
+        seqIn = SequencerInbox(address(new ERC1967Proxy(address(implementationSequencer), seqInInitData)));
+        vm.stopPrank();
+
+        // Making sure that the proxy returns the correct proxy owner and sequencerAddress
+        address sequencerInboxDeployer = seqIn.owner();
+        assertEq(sequencerInboxDeployer, deployer);
+
+        address fetchedSequencerAddress = seqIn.sequencerAddress();
+        assertEq(fetchedSequencerAddress, sequencerAddress);
+    }
+
+    function test_confirmationPeriodChangedWhen_callerIsDeployer() public {
+        bytes memory initializingData = abi.encodeWithSelector(
+                    Rollup.initialize.selector,
+                    sequencerAddress, // vault
+                    address(seqIn),
+                    address(verifier),
+                    0, //confirmationPeriod
+                    0, //challengePeriod
+                    0, // minimumAssertionPeriod
+                    0, //baseStakeAmount,
+                    0, // initialAssertionID
+                    0, // initialInboxSize
+                    bytes32("")
+                );
+
+        vm.startPrank(deployer);
+
+        Rollup implementationRollup = new Rollup(); // implementation contract
+        rollup = Rollup(address(new ERC1967Proxy(address(implementationRollup), initializingData))); // The rollup contract (proxy, not implementation should have been initialized by now)
+        
+
+        assertEq(rollup.confirmationPeriod(), 0);
+        vm.expectEmit(false, false, false, true);
+        emit ConfigurationChanged();
+
+        rollup.setConfirmationPeriod(10);
+        assertEq(rollup.confirmationPeriod(), 10);
+
+        vm.stopPrank();
+    }
+
+        function test_confirmationPeriodNotChangedWhen_callerIsNotDeployer() public {
+        bytes memory initializingData = abi.encodeWithSelector(
+                    Rollup.initialize.selector,
+                    sequencerAddress, // vault
+                    address(seqIn),
+                    address(verifier),
+                    0, //confirmationPeriod
+                    0, //challengePeriod
+                    0, // minimumAssertionPeriod
+                    0, //baseStakeAmount,
+                    0, // initialAssertionID
+                    0, // initialInboxSize
+                    bytes32("")
+                );
+
+        vm.startPrank(deployer);
+
+        Rollup implementationRollup = new Rollup(); // implementation contract
+        rollup = Rollup(address(new ERC1967Proxy(address(implementationRollup), initializingData))); // The rollup contract (proxy, not implementation should have been initialized by now)
+        
+        vm.stopPrank();
+
+        // now, try with sequencer address
+        vm.startPrank(sequencerAddress);
+        
+        assertEq(rollup.confirmationPeriod(), 0);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rollup.setConfirmationPeriod(10);
+        assertEq(rollup.confirmationPeriod(), 0);
+
+        vm.stopPrank();
+    }
+
+}

--- a/contracts/test/RollUp.t.sol
+++ b/contracts/test/RollUp.t.sol
@@ -66,10 +66,20 @@ contract RollupTest is RollupBaseSetup {
         RollupBaseSetup.setUp();
 
         // Deploying the SequencerInbox
-        bytes memory seqInInitData = abi.encodeWithSignature("initialize(address)", sequencerAddress);
+        bytes memory seqInInitData = abi.encodeWithSignature(
+            "initialize(address)",
+            sequencerAddress
+        );
         vm.startPrank(deployer);
         implementationSequencer = new SequencerInbox();
-        seqIn = SequencerInbox(address(new ERC1967Proxy(address(implementationSequencer), seqInInitData)));
+        seqIn = SequencerInbox(
+            address(
+                new ERC1967Proxy(
+                    address(implementationSequencer),
+                    seqInInitData
+                )
+            )
+        );
         vm.stopPrank();
 
         // Making sure that the proxy returns the correct proxy owner and sequencerAddress
@@ -80,68 +90,150 @@ contract RollupTest is RollupBaseSetup {
         assertEq(fetchedSequencerAddress, sequencerAddress);
     }
 
-    function test_confirmationPeriodChangedWhen_callerIsDeployer() public {
+    // test changes for parameters: confirmationPeriod, challengePeriod, minimumAssertionPeriod, baseStakeAmount
+    function test_parametersChangedWhen_callerIsDeployer() public {
         bytes memory initializingData = abi.encodeWithSelector(
-                    Rollup.initialize.selector,
-                    sequencerAddress, // vault
-                    address(seqIn),
-                    address(verifier),
-                    0, //confirmationPeriod
-                    0, //challengePeriod
-                    0, // minimumAssertionPeriod
-                    0, //baseStakeAmount,
-                    0, // initialAssertionID
-                    0, // initialInboxSize
-                    bytes32("")
-                );
+            Rollup.initialize.selector,
+            sequencerAddress, // vault
+            address(seqIn),
+            address(verifier),
+            0, //confirmationPeriod
+            0, //challengePeriod
+            0, // minimumAssertionPeriod
+            20, //baseStakeAmount, it can only decrease so high initial value to test
+            0, // initialAssertionID
+            0, // initialInboxSize
+            bytes32("")
+        );
 
         vm.startPrank(deployer);
 
         Rollup implementationRollup = new Rollup(); // implementation contract
-        rollup = Rollup(address(new ERC1967Proxy(address(implementationRollup), initializingData))); // The rollup contract (proxy, not implementation should have been initialized by now)
-        
+        rollup = Rollup(
+            address(
+                new ERC1967Proxy(
+                    address(implementationRollup),
+                    initializingData
+                )
+            )
+        ); // The rollup contract (proxy, not implementation should have been initialized by now)
 
         assertEq(rollup.confirmationPeriod(), 0);
         vm.expectEmit(false, false, false, true);
         emit ConfigurationChanged();
-
         rollup.setConfirmationPeriod(10);
         assertEq(rollup.confirmationPeriod(), 10);
+
+        assertEq(rollup.challengePeriod(), 0);
+        vm.expectEmit(false, false, false, true);
+        emit ConfigurationChanged();
+        rollup.setChallengePeriod(10);
+        assertEq(rollup.challengePeriod(), 10);
+
+        assertEq(rollup.minimumAssertionPeriod(), 0);
+        vm.expectEmit(false, false, false, true);
+        emit ConfigurationChanged();
+        rollup.setMinimumAssertionPeriod(10);
+        assertEq(rollup.minimumAssertionPeriod(), 10);
+
+        assertEq(rollup.baseStakeAmount(), 20);
+        vm.expectEmit(false, false, false, true);
+        emit ConfigurationChanged();
+        rollup.setBaseStakeAmount(10);
+        assertEq(rollup.baseStakeAmount(), 10);
 
         vm.stopPrank();
     }
 
-        function test_confirmationPeriodNotChangedWhen_callerIsNotDeployer() public {
+    function test_parametersNotChangedWhen_callerIsNotDeployer() public {
         bytes memory initializingData = abi.encodeWithSelector(
-                    Rollup.initialize.selector,
-                    sequencerAddress, // vault
-                    address(seqIn),
-                    address(verifier),
-                    0, //confirmationPeriod
-                    0, //challengePeriod
-                    0, // minimumAssertionPeriod
-                    0, //baseStakeAmount,
-                    0, // initialAssertionID
-                    0, // initialInboxSize
-                    bytes32("")
-                );
+            Rollup.initialize.selector,
+            sequencerAddress, // vault
+            address(seqIn),
+            address(verifier),
+            0, //confirmationPeriod
+            0, //challengePeriod
+            0, // minimumAssertionPeriod
+            20, //baseStakeAmount,
+            0, // initialAssertionID
+            0, // initialInboxSize
+            bytes32("")
+        );
 
         vm.startPrank(deployer);
 
         Rollup implementationRollup = new Rollup(); // implementation contract
-        rollup = Rollup(address(new ERC1967Proxy(address(implementationRollup), initializingData))); // The rollup contract (proxy, not implementation should have been initialized by now)
-        
+        rollup = Rollup(
+            address(
+                new ERC1967Proxy(
+                    address(implementationRollup),
+                    initializingData
+                )
+            )
+        ); // The rollup contract (proxy, not implementation should have been initialized by now)
+
         vm.stopPrank();
 
         // now, try with sequencer address
         vm.startPrank(sequencerAddress);
-        
+
         assertEq(rollup.confirmationPeriod(), 0);
         vm.expectRevert("Ownable: caller is not the owner");
         rollup.setConfirmationPeriod(10);
         assertEq(rollup.confirmationPeriod(), 0);
 
+        assertEq(rollup.challengePeriod(), 0);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rollup.setChallengePeriod(10);
+        assertEq(rollup.challengePeriod(), 0);
+
+        assertEq(rollup.minimumAssertionPeriod(), 0);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rollup.setMinimumAssertionPeriod(10);
+        assertEq(rollup.minimumAssertionPeriod(), 0);
+
+        assertEq(rollup.baseStakeAmount(), 20);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rollup.setBaseStakeAmount(10);
+        vm.expectRevert("Ownable: caller is not the owner");
+        rollup.setBaseStakeAmount(30);
+        assertEq(rollup.baseStakeAmount(), 20);
+
         vm.stopPrank();
     }
 
+    function test_baseStakeChangeFailsIf_setToBeHigher() public {
+        bytes memory initializingData = abi.encodeWithSelector(
+            Rollup.initialize.selector,
+            sequencerAddress, // vault
+            address(seqIn),
+            address(verifier),
+            0, //confirmationPeriod
+            0, //challengePeriod
+            0, // minimumAssertionPeriod
+            0, //baseStakeAmount,
+            0, // initialAssertionID
+            0, // initialInboxSize
+            bytes32("")
+        );
+
+        vm.startPrank(deployer);
+
+        Rollup implementationRollup = new Rollup(); // implementation contract
+        rollup = Rollup(
+            address(
+                new ERC1967Proxy(
+                    address(implementationRollup),
+                    initializingData
+                )
+            )
+        ); // The rollup contract (proxy, not implementation should have been initialized by now)
+
+        assertEq(rollup.baseStakeAmount(), 0);
+        vm.expectRevert("Cannot increase base stake amount");
+        rollup.setBaseStakeAmount(10);
+        assertEq(rollup.baseStakeAmount(), 0);
+
+        vm.stopPrank();
+    }
 }

--- a/contracts/test/RollUp.t.sol
+++ b/contracts/test/RollUp.t.sol
@@ -227,7 +227,7 @@ contract RollupTest is RollupBaseSetup {
         ); // The rollup contract (proxy, not implementation should have been initialized by now)
 
         assertEq(rollup.baseStakeAmount(), 0);
-        vm.expectRevert("Cannot increase base stake amount");
+        vm.expectRevert(IRollup.IncreaseStake.selector);
         rollup.setBaseStakeAmount(10);
         assertEq(rollup.baseStakeAmount(), 0);
 


### PR DESCRIPTION
# Added setters and tests for parameters in RollupBase

Core changes:

- new event `ConfigurationChanged()`
- setter functions
- tests

Notes:

- `baseStakeAmount `can only be decreased
