### PR TITLE
using ++i instead of i++ to save gas

### DIFF
--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -529,7 +529,7 @@ contract Rollup is RollupBase {
      */
     function countStakedZombies(uint256 assertionID) private view returns (uint256) {
         uint256 numStakedZombies = 0;
-        for (uint256 i = 0; i < zombies.length; i++) {
+        for (uint256 i = 0; i < zombies.length; ++i) {
             if (assertionState[assertionID].stakers[zombies[i].stakerAddress]) {
                 numStakedZombies++;
             }


### PR DESCRIPTION
# Saving more gas

Core changes:

- [[contracts/src/Rollup.sol#L532](https://github.com/SpecularL2/specular/blob/51a0826178f9f7389022b015c1a87023cb139b31/contracts/src/Rollup.sol#L532)]

Notes:

- using ++i instead of i++ could save more gas
