### PR TITLE
Added the condition for confirming and rejecting Assertions

### DIFF
--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -300,6 +301,11 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 			// New assertion confirmed
 			if pendingAssertion.ID.Cmp(id) == 0 {
 				confirmedAssertion = pendingAssertion
+				opts := bind.FilterOpts{Start: s.Config.L1RollupGenesisBlock, Context: ctx}
+				err = s.L1Client.RemoveStakesOnLastConfirmed(&opts, confirmedAssertion.ID)
+				if err != nil {
+					log.Error("Failed to remove staker stake for assertion %s, err: %w", confirmedAssertion.ID, err)
+				}
 				if pendingAssertion.VmHash == queuedAssertion.VmHash {
 					// We are done here, waiting for new batches
 					pendingAssertion = nil

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -211,6 +211,8 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 		s.L1Client.FilterAssertionCreated,
 		s.L1Syncer.Latest.Number.Uint64(),
 	)
+	// Watch AssertionQueued event
+	opts := bind.FilterOpts{Start: s.Config.L1RollupGenesisBlock, Context: ctx}
 
 	// Last validated assertion, initalize it to genesis
 	// TODO: change name to lastValidatedAssertion since "confirmed" may imply L1-confirmed.
@@ -301,7 +303,6 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 			// New assertion confirmed
 			if pendingAssertion.ID.Cmp(id) == 0 {
 				confirmedAssertion = pendingAssertion
-				opts := bind.FilterOpts{Start: s.Config.L1RollupGenesisBlock, Context: ctx}
 				err = s.L1Client.RemoveStakesOnLastConfirmed(&opts, confirmedAssertion.ID)
 				if err != nil {
 					log.Error("Failed to remove staker stake for assertion %s, err: %w", confirmedAssertion.ID, err)

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -211,7 +211,7 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 		s.L1Client.FilterAssertionCreated,
 		s.L1Syncer.Latest.Number.Uint64(),
 	)
-	// Watch AssertionQueued event
+
 	opts := bind.FilterOpts{Start: s.Config.L1RollupGenesisBlock, Context: ctx}
 
 	// Last validated assertion, initalize it to genesis


### PR DESCRIPTION
# Goals of PR

Core changes:

- Added the condition for confirming and rejecting Assertions
- Add RemoveStakesOnLastConfirmed function to remove staked validators on last confirmed assertion

Notes:

- Assertion's parent should be confirmed so we assumed assertions are processed one after another so the parent of the current assertion should be the last confirmed Assertion. Else we can make an array of all confirmed assertions.
- Used sequencer's address for staker's address in `RejectFirstUnresolvedAssertion ` as on calling `createAssertion` we also stake on the assertion, so assumed that sequencer created the assertions. Else we can have a function to get stakers on any assertion
