### PR TITLE
Remove block# redundancy in appendTxBatch

### DIFF
--- a/clients/geth/specular/bindings/ISequencerInbox.go
+++ b/clients/geth/specular/bindings/ISequencerInbox.go
@@ -30,7 +30,7 @@ var (
 
 // ISequencerInboxMetaData contains all meta data concerning the ISequencerInbox contract.
 var ISequencerInboxMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[],\"name\":\"EmptyBatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ProofVerificationFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TxBatchDataOverflow\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"batchNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"startTxNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"endTxNumber\",\"type\":\"uint256\"}],\"name\":\"TxBatchAppended\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"contexts\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"txLengths\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"txBatch\",\"type\":\"bytes\"}],\"name\":\"appendTxBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getInboxSize\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"encodedTx\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"verifyTxInclusion\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[],\"name\":\"EmptyBatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ProofVerificationFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TxBatchDataOverflow\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"batchNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"startTxNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"endTxNumber\",\"type\":\"uint256\"}],\"name\":\"TxBatchAppended\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"contexts\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"txLengths\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"firstL2BlockNumber\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"txBatch\",\"type\":\"bytes\"}],\"name\":\"appendTxBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getInboxSize\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"encodedTx\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"proof\",\"type\":\"bytes\"}],\"name\":\"verifyTxInclusion\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // ISequencerInboxABI is the input ABI used to generate the binding from.
@@ -239,25 +239,25 @@ func (_ISequencerInbox *ISequencerInboxCallerSession) VerifyTxInclusion(encodedT
 	return _ISequencerInbox.Contract.VerifyTxInclusion(&_ISequencerInbox.CallOpts, encodedTx, proof)
 }
 
-// AppendTxBatch is a paid mutator transaction binding the contract method 0x66ac980a.
+// AppendTxBatch is a paid mutator transaction binding the contract method 0xe1804b49.
 //
-// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, bytes txBatch) returns()
-func (_ISequencerInbox *ISequencerInboxTransactor) AppendTxBatch(opts *bind.TransactOpts, contexts []*big.Int, txLengths []*big.Int, txBatch []byte) (*types.Transaction, error) {
-	return _ISequencerInbox.contract.Transact(opts, "appendTxBatch", contexts, txLengths, txBatch)
+// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, uint256 firstL2BlockNumber, bytes txBatch) returns()
+func (_ISequencerInbox *ISequencerInboxTransactor) AppendTxBatch(opts *bind.TransactOpts, contexts []*big.Int, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatch []byte) (*types.Transaction, error) {
+	return _ISequencerInbox.contract.Transact(opts, "appendTxBatch", contexts, txLengths, firstL2BlockNumber, txBatch)
 }
 
-// AppendTxBatch is a paid mutator transaction binding the contract method 0x66ac980a.
+// AppendTxBatch is a paid mutator transaction binding the contract method 0xe1804b49.
 //
-// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, bytes txBatch) returns()
-func (_ISequencerInbox *ISequencerInboxSession) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, txBatch []byte) (*types.Transaction, error) {
-	return _ISequencerInbox.Contract.AppendTxBatch(&_ISequencerInbox.TransactOpts, contexts, txLengths, txBatch)
+// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, uint256 firstL2BlockNumber, bytes txBatch) returns()
+func (_ISequencerInbox *ISequencerInboxSession) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatch []byte) (*types.Transaction, error) {
+	return _ISequencerInbox.Contract.AppendTxBatch(&_ISequencerInbox.TransactOpts, contexts, txLengths, firstL2BlockNumber, txBatch)
 }
 
-// AppendTxBatch is a paid mutator transaction binding the contract method 0x66ac980a.
+// AppendTxBatch is a paid mutator transaction binding the contract method 0xe1804b49.
 //
-// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, bytes txBatch) returns()
-func (_ISequencerInbox *ISequencerInboxTransactorSession) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, txBatch []byte) (*types.Transaction, error) {
-	return _ISequencerInbox.Contract.AppendTxBatch(&_ISequencerInbox.TransactOpts, contexts, txLengths, txBatch)
+// Solidity: function appendTxBatch(uint256[] contexts, uint256[] txLengths, uint256 firstL2BlockNumber, bytes txBatch) returns()
+func (_ISequencerInbox *ISequencerInboxTransactorSession) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatch []byte) (*types.Transaction, error) {
+	return _ISequencerInbox.Contract.AppendTxBatch(&_ISequencerInbox.TransactOpts, contexts, txLengths, firstL2BlockNumber, txBatch)
 }
 
 // ISequencerInboxTxBatchAppendedIterator is returned from FilterTxBatchAppended and is used to iterate over the raw logs and unpacked data for TxBatchAppended events raised by the ISequencerInbox contract.

--- a/clients/geth/specular/rollup/client/l1client.go
+++ b/clients/geth/specular/rollup/client/l1client.go
@@ -32,7 +32,7 @@ type L1BridgeClient interface {
 	) event.Subscription
 	Close()
 	// ISequencerInbox.sol
-	AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, txBatch []byte) (*types.Transaction, error)
+	AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2Block *big.Int, txBatch []byte) (*types.Transaction, error)
 	WatchTxBatchAppended(opts *bind.WatchOpts, sink chan<- *bindings.ISequencerInboxTxBatchAppended) (event.Subscription, error)
 	FilterTxBatchAppendedEvents(opts *bind.FilterOpts) (*bindings.ISequencerInboxTxBatchAppendedIterator, error)
 	DecodeAppendTxBatchInput(tx *types.Transaction) ([]interface{}, error)
@@ -230,10 +230,10 @@ func (c *EthBridgeClient) Close() {
 	c.client.Close()
 }
 
-func (c *EthBridgeClient) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, txBatch []byte) (*types.Transaction, error) {
+func (c *EthBridgeClient) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2Block *big.Int, txBatch []byte) (*types.Transaction, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	f := func() (*types.Transaction, error) { return c.inbox.AppendTxBatch(contexts, txLengths, txBatch) }
+	f := func() (*types.Transaction, error) { return c.inbox.AppendTxBatch(contexts, txLengths, firstL2Block, txBatch) }
 	return retryTransactingFunction(f, c.retryOpts)
 }
 

--- a/clients/geth/specular/rollup/client/l1client.go
+++ b/clients/geth/specular/rollup/client/l1client.go
@@ -32,7 +32,7 @@ type L1BridgeClient interface {
 	) event.Subscription
 	Close()
 	// ISequencerInbox.sol
-	AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2Block *big.Int, txBatch []byte) (*types.Transaction, error)
+	AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatch []byte) (*types.Transaction, error)
 	WatchTxBatchAppended(opts *bind.WatchOpts, sink chan<- *bindings.ISequencerInboxTxBatchAppended) (event.Subscription, error)
 	FilterTxBatchAppendedEvents(opts *bind.FilterOpts) (*bindings.ISequencerInboxTxBatchAppendedIterator, error)
 	DecodeAppendTxBatchInput(tx *types.Transaction) ([]interface{}, error)
@@ -230,10 +230,10 @@ func (c *EthBridgeClient) Close() {
 	c.client.Close()
 }
 
-func (c *EthBridgeClient) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2Block *big.Int, txBatch []byte) (*types.Transaction, error) {
+func (c *EthBridgeClient) AppendTxBatch(contexts []*big.Int, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatch []byte) (*types.Transaction, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	f := func() (*types.Transaction, error) { return c.inbox.AppendTxBatch(contexts, txLengths, firstL2Block, txBatch) }
+	f := func() (*types.Transaction, error) { return c.inbox.AppendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch) }
 	return retryTransactingFunction(f, c.retryOpts)
 }
 

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -252,12 +252,19 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 				continue
 			}
 			batch := rollupTypes.NewTxBatch(batchBlocks, 0) // TODO: handle max batch size
-			contexts, txLengths, txs, err := batch.SerializeToArgs()
+			contexts, txLengths, firstL2Block, txs, err := batch.SerializeToArgs()
 			if err != nil {
 				log.Error("Can not serialize batch", "error", err)
 				continue
 			}
-			_, err = s.L1Client.AppendTxBatch(contexts, txLengths, txs)
+			log.Info(
+				"Serialized new Tx Batch",
+				"#txs", len(batch.Txs),
+				"#numBlocks", len(contexts) / 2,
+				"#firsBlockNumber", firstL2Block,
+			)
+
+			_, err = s.L1Client.AppendTxBatch(contexts, txLengths, firstL2Block, txs)
 			if errors.Is(err, core.ErrInsufficientFunds) {
 				log.Crit("Insufficient Funds to send Tx", "error", err)
 			}

--- a/clients/geth/specular/rollup/services/sequencer/sequencer.go
+++ b/clients/geth/specular/rollup/services/sequencer/sequencer.go
@@ -252,7 +252,7 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 				continue
 			}
 			batch := rollupTypes.NewTxBatch(batchBlocks, 0) // TODO: handle max batch size
-			contexts, txLengths, firstL2Block, txs, err := batch.SerializeToArgs()
+			contexts, txLengths, firstL2BlockNumber, txs, err := batch.SerializeToArgs()
 			if err != nil {
 				log.Error("Can not serialize batch", "error", err)
 				continue
@@ -261,10 +261,10 @@ func (s *Sequencer) sequencingLoop(ctx context.Context) {
 				"Serialized new Tx Batch",
 				"#txs", len(batch.Txs),
 				"#numBlocks", len(contexts) / 2,
-				"#firsBlockNumber", firstL2Block,
+				"#firsBlockNumber", firstL2BlockNumber,
 			)
 
-			_, err = s.L1Client.AppendTxBatch(contexts, txLengths, firstL2Block, txs)
+			_, err = s.L1Client.AppendTxBatch(contexts, txLengths, firstL2BlockNumber, txs)
 			if errors.Is(err, core.ErrInsufficientFunds) {
 				log.Crit("Insufficient Funds to send Tx", "error", err)
 			}

--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -36,15 +36,6 @@ func (e *errAssertionOverflowedLocalInbox) Error() string {
 	return fmt.Sprint("assertion overflowed local inbox with msg:", e.Msg)
 }
 
-func (e *errAssertionOverflowedLocalInbox) Is(tgt error) bool {
-	_, ok := tgt.(*errAssertionOverflowedLocalInbox)
-	return ok
-}
-
-
-
-
-
 type Validator struct {
 	*services.BaseService
 

--- a/clients/geth/specular/rollup/types/tx_batch.go
+++ b/clients/geth/specular/rollup/types/tx_batch.go
@@ -14,11 +14,11 @@ import (
 // TxBatch represents a transaction batch to be sequenced to L1 sequencer inbox
 // It may contain multiple blocks
 type TxBatch struct {
-	Blocks				types.Blocks
-	FirstL2BlockNumber  *big.Int
-	Contexts			[]SequenceContext
-	Txs					types.Transactions
-	GasUsed				*big.Int
+	Blocks             types.Blocks
+	FirstL2BlockNumber *big.Int
+	Contexts           []SequenceContext
+	Txs                types.Transactions
+	GasUsed            *big.Int
 }
 
 // SequenceBlock represents a block sequenced to L1 sequencer inbox
@@ -30,8 +30,8 @@ type SequenceBlock struct {
 
 // SequenceContext is the relavent context of each block sequenced to L1 sequncer inbox
 type SequenceContext struct {
-	NumTxs      uint64
-	Timestamp   uint64
+	NumTxs    uint64
+	Timestamp uint64
 }
 
 type DecodeTxBatchError struct{ msg string }
@@ -51,8 +51,8 @@ func NewTxBatch(blocks []*types.Block, maxBatchSize uint64) *TxBatch {
 	for _, block := range blocks {
 		blockTxs := block.Transactions()
 		ctx := SequenceContext{
-			NumTxs:      uint64(len(blockTxs)),
-			Timestamp:   block.Time(),
+			NumTxs:    uint64(len(blockTxs)),
+			Timestamp: block.Time(),
 		}
 		contexts = append(contexts, ctx)
 		txs = append(txs, blockTxs...)
@@ -143,7 +143,7 @@ func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
 	firstL2BlockNumber := decoded[2].(*big.Int)
 	txBatch := decoded[3].([]byte)
 
-	if len(contexts) % 2 != 0 {
+	if len(contexts)%2 != 0 {
 		return nil, &DecodeTxBatchError{fmt.Sprintf("invalid contexts length %d", len(contexts))}
 	}
 
@@ -153,8 +153,8 @@ func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
 	var numTxs uint64
 	for i := 0; i < len(contexts); i += 2 {
 		ctx := SequenceContext{
-			NumTxs:      contexts[i].Uint64(),
-			Timestamp:   contexts[i+1].Uint64(),
+			NumTxs:    contexts[i].Uint64(),
+			Timestamp: contexts[i+1].Uint64(),
 		}
 		ctxs = append(ctxs, ctx)
 		for j := uint64(0); j < ctx.NumTxs; j++ {
@@ -171,8 +171,8 @@ func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
 	}
 	batch := &TxBatch{
 		FirstL2BlockNumber: firstL2BlockNumber,
-		Contexts: ctxs,
-		Txs:      txs,
+		Contexts:           ctxs,
+		Txs:                txs,
 	}
 	return batch, nil
 }

--- a/clients/geth/specular/rollup/types/tx_batch.go
+++ b/clients/geth/specular/rollup/types/tx_batch.go
@@ -46,7 +46,6 @@ func NewTxBatch(blocks []*types.Block, maxBatchSize uint64) *TxBatch {
 	var txs []*types.Transaction
 	gasUsed := new(big.Int)
 
-	// TODO: do we need to handle the case where blocks is empty
 	firstL2BlockNumber := blocks[0].Number()
 
 	for _, block := range blocks {

--- a/clients/geth/specular/rollup/types/tx_batch.go
+++ b/clients/geth/specular/rollup/types/tx_batch.go
@@ -14,10 +14,11 @@ import (
 // TxBatch represents a transaction batch to be sequenced to L1 sequencer inbox
 // It may contain multiple blocks
 type TxBatch struct {
-	Blocks   types.Blocks
-	Contexts []SequenceContext
-	Txs      types.Transactions
-	GasUsed  *big.Int
+	Blocks				types.Blocks
+	FirstL2BlockNumber  *big.Int
+	Contexts			[]SequenceContext
+	Txs					types.Transactions
+	GasUsed				*big.Int
 }
 
 // SequenceBlock represents a block sequenced to L1 sequencer inbox
@@ -30,7 +31,6 @@ type SequenceBlock struct {
 // SequenceContext is the relavent context of each block sequenced to L1 sequncer inbox
 type SequenceContext struct {
 	NumTxs      uint64
-	BlockNumber uint64
 	Timestamp   uint64
 }
 
@@ -45,22 +45,26 @@ func NewTxBatch(blocks []*types.Block, maxBatchSize uint64) *TxBatch {
 	var contexts []SequenceContext
 	var txs []*types.Transaction
 	gasUsed := new(big.Int)
+
+	// TODO: do we need to handle the case where blocks is empty
+	firstL2BlockNumber := blocks[0].Number()
+
 	for _, block := range blocks {
 		blockTxs := block.Transactions()
 		ctx := SequenceContext{
 			NumTxs:      uint64(len(blockTxs)),
-			BlockNumber: block.Number().Uint64(), // TODO just use bigint
 			Timestamp:   block.Time(),
 		}
 		contexts = append(contexts, ctx)
 		txs = append(txs, blockTxs...)
 		gasUsed.Add(gasUsed, new(big.Int).SetUint64(block.GasUsed()))
 	}
-	return &TxBatch{blocks, contexts, txs, gasUsed}
+
+	return &TxBatch{blocks, firstL2BlockNumber, contexts, txs, gasUsed}
 }
 
 func (b *TxBatch) LastBlockNumber() uint64 {
-	return b.Contexts[len(b.Contexts)-1].BlockNumber
+	return b.FirstL2BlockNumber.Uint64() + uint64(len(b.Contexts)) - 1
 }
 
 func (b *TxBatch) LastBlockRoot() common.Hash {
@@ -71,11 +75,10 @@ func (b *TxBatch) InboxSize() *big.Int {
 	return new(big.Int).SetUint64(uint64(b.Txs.Len()))
 }
 
-func (b *TxBatch) SerializeToArgs() ([]*big.Int, []*big.Int, []byte, error) {
+func (b *TxBatch) SerializeToArgs() ([]*big.Int, []*big.Int, *big.Int, []byte, error) {
 	var contexts, txLengths []*big.Int
 	for _, ctx := range b.Contexts {
 		contexts = append(contexts, big.NewInt(0).SetUint64(ctx.NumTxs))
-		contexts = append(contexts, big.NewInt(0).SetUint64(ctx.BlockNumber))
 		contexts = append(contexts, big.NewInt(0).SetUint64(ctx.Timestamp))
 	}
 
@@ -83,17 +86,21 @@ func (b *TxBatch) SerializeToArgs() ([]*big.Int, []*big.Int, []byte, error) {
 	for _, tx := range b.Txs {
 		curLen := buf.Len()
 		if err := writeTx(buf, tx); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		txLengths = append(txLengths, big.NewInt(int64(buf.Len()-curLen)))
 	}
-	return contexts, txLengths, buf.Bytes(), nil
+
+	firstL2BlockNumber := b.FirstL2BlockNumber
+
+	return contexts, txLengths, firstL2BlockNumber, buf.Bytes(), nil
 }
 
 // Splits batch into blocks
 func (b *TxBatch) SplitToBlocks() []*SequenceBlock {
 	txNum := 0
 	blocks := make([]*SequenceBlock, 0, len(b.Contexts))
+
 	for _, ctx := range b.Contexts {
 		block := &SequenceBlock{
 			SequenceContext: ctx,
@@ -107,9 +114,6 @@ func (b *TxBatch) SplitToBlocks() []*SequenceBlock {
 
 func writeContext(w *bytes.Buffer, ctx *SequenceContext) error {
 	if err := writePrimitive(w, ctx.NumTxs); err != nil {
-		return err
-	}
-	if err := writePrimitive(w, ctx.BlockNumber); err != nil {
 		return err
 	}
 	return writePrimitive(w, ctx.Timestamp)
@@ -132,13 +136,15 @@ func writePrimitive(w *bytes.Buffer, data interface{}) error {
 // TxBatchFromDecoded decodes the input of SequencerInbox#appendTxBatch call
 // It will only fill Contexts and Txs fields
 func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
-	if len(decoded) != 3 {
+	if len(decoded) != 4 {
 		return nil, &DecodeTxBatchError{fmt.Sprintf("invalid decoded array length %d", len(decoded))}
 	}
 	contexts := decoded[0].([]*big.Int)
 	txLengths := decoded[1].([]*big.Int)
-	txBatch := decoded[2].([]byte)
-	if len(contexts)%3 != 0 {
+	firstL2BlockNumber := decoded[2].(*big.Int)
+	txBatch := decoded[3].([]byte)
+
+	if len(contexts) % 2 != 0 {
 		return nil, &DecodeTxBatchError{fmt.Sprintf("invalid contexts length %d", len(contexts))}
 	}
 
@@ -146,11 +152,10 @@ func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
 	var ctxs []SequenceContext
 	var batchOffset uint64
 	var numTxs uint64
-	for i := 0; i < len(contexts); i += 3 {
+	for i := 0; i < len(contexts); i += 2 {
 		ctx := SequenceContext{
 			NumTxs:      contexts[i].Uint64(),
-			BlockNumber: contexts[i+1].Uint64(),
-			Timestamp:   contexts[i+2].Uint64(),
+			Timestamp:   contexts[i+1].Uint64(),
 		}
 		ctxs = append(ctxs, ctx)
 		for j := uint64(0); j < ctx.NumTxs; j++ {
@@ -166,6 +171,7 @@ func TxBatchFromDecoded(decoded []interface{}) (*TxBatch, error) {
 		}
 	}
 	batch := &TxBatch{
+		FirstL2BlockNumber: firstL2BlockNumber,
 		Contexts: ctxs,
 		Txs:      txs,
 	}

--- a/contracts/src/ISequencerInbox.sol
+++ b/contracts/src/ISequencerInbox.sol
@@ -41,11 +41,12 @@ interface ISequencerInbox is IDAProvider {
 
     /**
      * @notice Appends a batch of transactions (stored in calldata) and emits a TxBatchAppended event.
-     * @param contexts Array of contexts, where each context is represented by a uint256 3-tuple:
-     * (numTxs, l2BlockNumber, l2Timestamp). Each context corresponds to a single "L2 block".
+     * @param contexts Array of contexts, where each context is represented by a uint256 2-tuple:
+     * (numTxs, l2Timestamp). Each context corresponds to a single "L2 block".
      * @param txLengths Array of lengths of each encoded tx in txBatch.
+     * @param firstL2BlockNumber The block number of the first "L2 block" included in this batch.
      * @param txBatch Batch of RLP-encoded transactions.
      */
-    function appendTxBatch(uint256[] calldata contexts, uint256[] calldata txLengths, bytes calldata txBatch)
+    function appendTxBatch(uint256[] calldata contexts, uint256[] calldata txLengths, uint256 firstL2BlockNumber, bytes calldata txBatch)
         external;
 }

--- a/contracts/src/ISequencerInbox.sol
+++ b/contracts/src/ISequencerInbox.sol
@@ -47,6 +47,10 @@ interface ISequencerInbox is IDAProvider {
      * @param firstL2BlockNumber The block number of the first "L2 block" included in this batch.
      * @param txBatch Batch of RLP-encoded transactions.
      */
-    function appendTxBatch(uint256[] calldata contexts, uint256[] calldata txLengths, uint256 firstL2BlockNumber, bytes calldata txBatch)
-        external;
+    function appendTxBatch(
+        uint256[] calldata contexts,
+        uint256[] calldata txLengths,
+        uint256 firstL2BlockNumber,
+        bytes calldata txBatch
+    ) external;
 }

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -64,10 +64,7 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
         uint256[] calldata txLengths,
         uint256 firstL2BlockNumber,
         bytes calldata txBatch
-    )
-    external
-    override
-    {
+    ) external override {
         if (msg.sender != sequencerAddress) {
             revert NotSequencer(msg.sender, sequencerAddress);
         }

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -578,24 +578,21 @@ contract RollupTest is RollupBaseSetup {
     // This function increases the inbox size by 6
     function _increaseSequencerInboxSize() internal {
         uint256 numTxnsPerBlock = 3;
+        uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Each context corresponds to a single "L2 block"
         // `contexts` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
         // Let's create an array of contexts
         uint256 timeStamp1 = block.timestamp / 10;
         uint256 timeStamp2 = block.timestamp / 5;
-        uint256 blockNumber1 = timeStamp1 / 20;
-        uint256 blockNumber2 = timeStamp2 / 20;
 
-        uint256[] memory contexts = new uint256[](6);
+        uint256[] memory contexts = new uint256[](4);
 
         // Let's assume that we had 2 blocks and each had 3 transactions
         contexts[0] = (numTxnsPerBlock);
-        contexts[1] = (blockNumber1);
-        contexts[2] = (timeStamp1);
-        contexts[3] = (numTxnsPerBlock);
-        contexts[4] = (blockNumber2);
-        contexts[5] = (timeStamp2);
+        contexts[1] = (timeStamp1);
+        contexts[2] = (numTxnsPerBlock);
+        contexts[3] = (timeStamp2);
 
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
@@ -604,7 +601,7 @@ contract RollupTest is RollupBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, txBatch);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
     }
 
     function _initializeRollup(

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -127,7 +127,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Let's create an array of contexts
         uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i; i < numContextsArrEntries; i += 2) {
+        for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
             // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
             contexts[i] = numTxnsPerBlock;
 
@@ -214,7 +214,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Let's create an array of contexts
         uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i; i < numContextsArrEntries; i += 2) {
+        for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
             // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
             contexts[i] = numTxnsPerBlock;
 

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -92,7 +92,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         vm.prank(alice);
         uint256[] memory contexts = new uint256[](1);
         uint256[] memory txLengths = new uint256[](1);
-        seqIn.appendTxBatch(contexts, txLengths, "0x");
+        seqIn.appendTxBatch(contexts, txLengths, 1, "0x");
     }
 
     function test_RevertWhen_EmptyBatch() public {
@@ -100,7 +100,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         vm.prank(sequencerAddress);
         uint256[] memory contexts = new uint256[](1);
         uint256[] memory txLengths = new uint256[](1);
-        seqIn.appendTxBatch(contexts, txLengths, "0x");
+        seqIn.appendTxBatch(contexts, txLengths, 1, "0x");
     }
 
     //////////////////////////////
@@ -115,24 +115,24 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Each context corresponds to a single "L2 block"
         uint256 numTxns = numTxnsPerBlock * txnBlocks;
-        uint256 numContextsArrEntries = 3 * txnBlocks; // Since each `context` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
+        // Each `context` is represented with uint256 2-tuple: (numTxs, l2Timestamp)
+        uint256 numContextsArrEntries = 2 * txnBlocks;
 
         // Making sure that the block.timestamp is a reasonable value (> txnBlocks)
         vm.warp(block.timestamp + (4 * txnBlocks));
         uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
-            // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
+        // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
+
+        uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Let's create an array of contexts
         uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i; i < numContextsArrEntries; i += 3) {
+        for (uint256 i; i < numContextsArrEntries; i += 2) {
             // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
             contexts[i] = numTxnsPerBlock;
 
-            // Formual Used for blockNumber: (txnBlock's block.timestamp) / 20;
-            contexts[i + 1] = txnBlockTimestamp / 20;
-
             // Formula used for blockTimestamp: (current block.timestamp) / 5x
-            contexts[i + 2] = txnBlockTimestamp;
+            contexts[i + 1] = txnBlockTimestamp;
 
             // The only requirement for timestamps for the transaction blocks is that, these timestamps are monotonically increasing.
             // So, let's increase the value of txnBlock's timestamp monotonically, in a way that is does not exceed current block.timestamp
@@ -145,7 +145,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, txBatch);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
         assertGt(inboxSizeFinal, inboxSizeInitial);
@@ -162,24 +162,22 @@ contract SequencerInboxTest is SequencerBaseSetup {
         uint256 numTxnsPerBlock = 3;
         uint256 inboxSizeInitial = seqIn.getInboxSize();
 
+        uint256 firstL2BlockNumber = block.timestamp / 20;
+
         // Each context corresponds to a single "L2 block"
-        // `contexts` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
+        // `contexts` is represented with uint256 2-tuple: (numTxs, l2Timestamp)
         // Let's create an array of contexts
         uint256 numTxns = numTxnsPerBlock * 2;
         uint256 timeStamp1 = block.timestamp / 10;
         uint256 timeStamp2 = block.timestamp / 5;
-        uint256 blockNumber1 = timeStamp1 / 20;
-        uint256 blockNumber2 = timeStamp2 / 20;
 
         uint256[] memory contexts = new uint256[](6);
 
         // Let's assume that we had 2 blocks and each had 3 transactions
         contexts[0] = (numTxnsPerBlock);
-        contexts[1] = (blockNumber1);
-        contexts[2] = (timeStamp1);
-        contexts[3] = (numTxnsPerBlock);
-        contexts[4] = (blockNumber2);
-        contexts[5] = (timeStamp2);
+        contexts[1] = (timeStamp1);
+        contexts[2] = (numTxnsPerBlock);
+        contexts[3] = (timeStamp2);
 
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
@@ -188,7 +186,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, txBatch);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 
@@ -205,24 +203,23 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Each context corresponds to a single "L2 block"
         uint256 numTxns = numTxnsPerBlock * txnBlocks;
-        uint256 numContextsArrEntries = 3 * txnBlocks; // Since each `context` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
+        uint256 numContextsArrEntries = 2 * txnBlocks; // Since each `context` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
 
         // Making sure that the block.timestamp is a reasonable value (> txnBlocks)
         vm.warp(block.timestamp + (4 * txnBlocks));
         uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
-            // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
+        // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
+
+        uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Let's create an array of contexts
         uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i; i < numContextsArrEntries; i += 3) {
+        for (uint256 i; i < numContextsArrEntries; i += 2) {
             // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
             contexts[i] = numTxnsPerBlock;
 
-            // Formual Used for blockNumber: (txnBlock's block.timestamp) / 20;
-            contexts[i + 1] = txnBlockTimestamp / 20;
-
             // Formula used for blockTimestamp: (current block.timestamp) / 5x
-            contexts[i + 2] = txnBlockTimestamp;
+            contexts[i + 1] = txnBlockTimestamp;
 
             // The only requirement for timestamps for the transaction blocks is that, these timestamps are monotonically increasing.
             // So, let's increase the value of txnBlock's timestamp monotonically, in a way that is does not exceed current block.timestamp
@@ -241,7 +238,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // Pranking as the sequencer and calling appendTxBatch (should throw the TxBatchDataOverflow error)
         vm.expectRevert(ISequencerInbox.TxBatchDataOverflow.selector);
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, txBatch);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////
@@ -253,20 +250,20 @@ contract SequencerInboxTest is SequencerBaseSetup {
         numTxnsPerBlock = bound(numTxnsPerBlock, 1, 150);
         uint256 inboxSizeInitial = seqIn.getInboxSize();
 
+        uint256 firstL2BlockNumber = block.timestamp / 20;
+
         // Each context corresponds to a single "L2 block"
         // `contexts` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
         // Let's create an array of contexts
         uint256 numTxns = numTxnsPerBlock * 2;
         uint256 timeStamp1 = block.timestamp / 10;
-        uint256 blockNumber1 = timeStamp1 / 20;
 
-        uint256[] memory contexts = new uint256[](4);
+        uint256[] memory contexts = new uint256[](3);
 
         // Let's assume that we had 2 blocks and each had 3 transactions, but we fail to pass the block.timestamp and block.number of the 2nd transaction block.
         contexts[0] = (numTxnsPerBlock);
-        contexts[1] = (blockNumber1);
-        contexts[2] = (timeStamp1);
-        contexts[3] = (numTxnsPerBlock);
+        contexts[1] = (timeStamp1);
+        contexts[2] = (numTxnsPerBlock);
 
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
@@ -274,7 +271,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, txBatch);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 


### PR DESCRIPTION
# Goals of PR

## Core changes:
In a `TxBatch` we no longer store the block number in every context. Instead we only store the first block number of the batch and can reconstruct the other block numbers by incrementing.

## Notes:
We can see this leads to a small reduction of gas cost

```
Blocks in Batch: 10
TXs per Block:   30

only first block number of the batch:
(runs: 10, μ: 1997645152, ~: 1997645110)

only first block number of the batch, context struct:
(runs: 10, μ: 1997787298, ~: 1997787299)

block number in every context:
(runs: 10, μ: 1997722666, ~: 1997722664)

```

```
Blocks in Batch: 5
TXs per Block:   30

only first block number of the batch:
(runs: 10, μ: 143393358, ~: 143393361)

only first block number of the batch, context struct:
(runs: 10, μ: 143414539, ~: 143414585)

block number in every context:
(runs: 10, μ: 143403939, ~: 143403944)

```
