### PR TITLE
automate genesis hash input

### DIFF
--- a/clients/geth/specular/sbin/export_genesis.sh
+++ b/clients/geth/specular/sbin/export_genesis.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+SBIN=`dirname $0`
+SBIN="`cd "$SBIN"; pwd`"
+. $SBIN/configure.sh
+. $SBIN/configure_system.sh
+cd $DATA_DIR
+
+args=(
+    --datadir ./data_sequencer
+    --verbosity 0
+)
+
+$GETH_SPECULAR_DIR/build/bin/geth "${args[@]}" dump 0


### PR DESCRIPTION
# Goals of PR

Core changes:

- currently the genesis hash is hardcoded in the deploy script, this adds a script to export the genesis hash from the sequencer and uses that during deployment
