### PR TITLE
Allow contract configurability w/o upgrade

### DIFF
--- a/contracts/src/IRollup.sol
+++ b/contracts/src/IRollup.sol
@@ -23,7 +23,6 @@
 pragma solidity ^0.8.0;
 
 interface IRollup {
-
     event ConfigurationChanged();
 
     event AssertionCreated(uint256 assertionID, address asserterAddr, bytes32 vmHash);

--- a/contracts/src/IRollup.sol
+++ b/contracts/src/IRollup.sol
@@ -23,7 +23,7 @@
 pragma solidity ^0.8.0;
 
 interface IRollup {
-    event ConfigurationChanged();
+    event ConfigChanged();
 
     event AssertionCreated(uint256 assertionID, address asserterAddr, bytes32 vmHash);
 
@@ -172,30 +172,45 @@ interface IRollup {
 
     /**
      * @notice Sets a new DA provider
+     *
+     * Emits: `ConfigChanged` event.
+     *
      * @param newDAProvider New DA provider
      */
     function setDAProvider(address newDAProvider) external;
 
     /**
      * @notice Sets a new confirmation period
+     *
+     * Emits: `ConfigChanged` event.
+     *
      * @param newPeriod New confirmation period
      */
     function setConfirmationPeriod(uint256 newPeriod) external;
 
     /**
      * @notice Sets a new challenge period
+     *
+     * Emits: `ConfigChanged` event.
+     *
      * @param newPeriod New challenge period
      */
     function setChallengePeriod(uint256 newPeriod) external;
 
     /**
      * @notice Sets a new minimum assertion period
+     *
+     * Emits: `ConfigChanged` event.
+     *
      * @param newPeriod New minimum assertion period
      */
     function setMinimumAssertionPeriod(uint256 newPeriod) external;
 
     /**
      * @notice Sets a new base stake amount.
+     *
+     * Emits: `ConfigChanged` event.
+     *
      * @param newAmount New base stake amount; this can currently only be decreased.
      */
     function setBaseStakeAmount(uint256 newAmount) external;

--- a/contracts/src/IRollup.sol
+++ b/contracts/src/IRollup.sol
@@ -23,6 +23,9 @@
 pragma solidity ^0.8.0;
 
 interface IRollup {
+
+    event ConfigurationChanged();
+
     event AssertionCreated(uint256 assertionID, address asserterAddr, bytes32 vmHash);
 
     event AssertionChallenged(uint256 assertionID, address challengeAddr);
@@ -34,6 +37,9 @@ interface IRollup {
     event StakerStaked(address stakerAddr, uint256 assertionID);
 
     // TODO: Include errors thrown in function documentation.
+
+    /// @dev Thrown when the new config parameter is invalid (configuration methods).
+    error InvalidConfigChange();
 
     /// @dev Thrown when assertion creation requested with invalid inbox size.
     error InvalidInboxSize();
@@ -83,8 +89,8 @@ interface IRollup {
     /// @dev Thrown when there is no unresolved assertion
     error NoUnresolvedAssertion();
 
-    /// @dev Thrown when the challenge period has not passed
-    error ChallengePeriodPending();
+    /// @dev Thrown when the confirmation period has not passed
+    error ConfirmationPeriodPending();
 
     /// @dev Thrown when the challenger and defender didn't attest to sibling assertions
     error NotSiblings();
@@ -134,6 +140,8 @@ interface IRollup {
         uint256 childInboxSize; // child assertion inbox state
     }
 
+    // *** Getters ***
+
     /**
      * @param addr Staker address.
      * @return Staker corresponding to address.
@@ -160,6 +168,40 @@ interface IRollup {
      * @return confirmedInboxSize size of inbox confirmed
      */
     function confirmedInboxSize() external view returns (uint256);
+
+    // *** Configuration ***
+
+    /**
+     * @notice Sets a new DA provider
+     * @param newDAProvider New DA provider
+     */
+    function setDAProvider(address newDAProvider) external;
+
+    /**
+     * @notice Sets a new confirmation period
+     * @param newPeriod New confirmation period
+     */
+    function setConfirmationPeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets a new challenge period
+     * @param newPeriod New challenge period
+     */
+    function setChallengePeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets a new minimum assertion period
+     * @param newPeriod New minimum assertion period
+     */
+    function setMinimumAssertionPeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Sets a new base stake amount.
+     * @param newAmount New base stake amount; this can currently only be decreased.
+     */
+    function setBaseStakeAmount(uint256 newAmount) external;
+
+    // *** State mutation ***
 
     /**
      * @notice Deposits stake on staker's current assertion (or the last confirmed assertion if not currently staked).
@@ -197,7 +239,7 @@ interface IRollup {
      * Block is represented by all transactions in range [prevInboxSize, inboxSize]. The latest staked DA of the sender
      * is considered to be the predecessor. Moves sender stake onto the new DA.
      *
-     * The new DA stores the hash of the parameters: H(l2GasUsed || vmHash)
+     * Emits: `AssertionCreated` and `StakerStaked` events.
      *
      * @param vmHash New VM hash.
      * @param inboxSize Size of inbox corresponding to assertion (number of transactions).

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -176,26 +176,39 @@ contract Rollup is RollupBase {
 
     /// @inheritdoc IRollup
     function setDAProvider(address newDAProvider) external override onlyOwner {
+        if (lastCreatedAssertionID > lastResolvedAssertionID) {
+            revert InvalidConfigChange();
+        }
         daProvider = IDAProvider(newDAProvider);
     }
 
     /// @inheritdoc IRollup
     function setConfirmationPeriod(uint256 newPeriod) external override onlyOwner {
+        if (lastCreatedAssertionID > lastResolvedAssertionID) {
+            revert InvalidConfigChange();
+        }
         confirmationPeriod = newPeriod;
     }
 
     /// @inheritdoc IRollup
     function setChallengePeriod(uint256 newPeriod) external override onlyOwner {
+        if (lastCreatedAssertionID > lastResolvedAssertionID) {
+            revert InvalidConfigChange();
+        }
+       challengePeriod = newPeriod;
     }
 
     /// @inheritdoc IRollup
     function setMinimumAssertionPeriod(uint256 newPeriod) external override onlyOwner {
+        if (lastCreatedAssertionID > lastResolvedAssertionID) {
+            revert InvalidConfigChange();
+        }
         minimumAssertionPeriod = newPeriod;
     }
 
     /// @inheritdoc IRollup
     function setBaseStakeAmount(uint256 newAmount) external override onlyOwner {
-        if (newAmount > baseStakeAmount) {
+        if (lastCreatedAssertionID != lastResolvedAssertionID || newAmount > baseStakeAmount) {
             revert InvalidConfigChange();
         }
         baseStakeAmount = newAmount;

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -99,11 +99,7 @@ contract Rollup is RollupBase {
         uint256 _initialInboxSize,
         bytes32 _initialVMhash
     ) public initializer {
-        if (
-            _vault == address(0) ||
-            _daProvider == address(0) ||
-            _verifier == address(0)
-        ) {
+        if (_vault == address(0) || _daProvider == address(0) || _verifier == address(0)) {
             revert ZeroAddress();
         }
         vault = _vault;
@@ -126,11 +122,7 @@ contract Rollup is RollupBase {
             _initialAssertionID, // parentID (doesn't matter, since unchallengeable)
             block.number // deadline (unchallengeable)
         );
-        emit AssertionCreated(
-            lastCreatedAssertionID,
-            msg.sender,
-            _initialVMhash
-        );
+        emit AssertionCreated(lastCreatedAssertionID, msg.sender, _initialVMhash);
 
         __RollupBase_init();
     }
@@ -153,24 +145,17 @@ contract Rollup is RollupBase {
     }
 
     /// @inheritdoc IRollup
-    function getStaker(
-        address addr
-    ) external view override returns (Staker memory) {
+    function getStaker(address addr) external view override returns (Staker memory) {
         return stakers[addr];
     }
 
     /// @inheritdoc IRollup
-    function getAssertion(
-        uint256 assertionID
-    ) external view override returns (Assertion memory) {
+    function getAssertion(uint256 assertionID) external view override returns (Assertion memory) {
         return assertions[assertionID];
     }
 
     /// @inheritdoc IRollup
-    function isStakedOnAssertion(
-        uint256 assertionID,
-        address stakerAddress
-    ) external view override returns (bool) {
+    function isStakedOnAssertion(uint256 assertionID, address stakerAddress) external view override returns (bool) {
         return assertionState[assertionID].stakers[stakerAddress];
     }
 
@@ -195,7 +180,7 @@ contract Rollup is RollupBase {
         if (lastCreatedAssertionID > lastResolvedAssertionID) {
             revert InvalidConfigChange();
         }
-       challengePeriod = newPeriod;
+        challengePeriod = newPeriod;
     }
 
     /// @inheritdoc IRollup
@@ -241,7 +226,7 @@ contract Rollup is RollupBase {
         }
         staker.amountStaked -= stakeAmount;
         // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
-        (bool success, ) = msg.sender.call{value: stakeAmount}("");
+        (bool success,) = msg.sender.call{value: stakeAmount}("");
         if (!success) revert TransferFailed();
     }
 
@@ -259,17 +244,14 @@ contract Rollup is RollupBase {
         // Note: we don't need to modify assertion state because you can only unstake from a confirmed assertion.
         deleteStaker(stakerAddress);
 
-        (bool success, ) = stakerAddress.call{value: stakerAmountStaked}("");
+        (bool success,) = stakerAddress.call{value: stakerAmountStaked}("");
         if (!success) revert TransferFailed();
     }
 
     /// @inheritdoc IRollup
     function advanceStake(uint256 assertionID) external override stakedOnly {
         Staker storage staker = stakers[msg.sender];
-        if (
-            assertionID <= staker.assertionID ||
-            assertionID > lastCreatedAssertionID
-        ) {
+        if (assertionID <= staker.assertionID || assertionID > lastCreatedAssertionID) {
             revert AssertionOutOfRange();
         }
         // TODO: allow arbitrary descendant of current staked assertionID, not just child.
@@ -283,15 +265,12 @@ contract Rollup is RollupBase {
     function withdraw() external override {
         uint256 withdrawableFund = withdrawableFunds[msg.sender];
         withdrawableFunds[msg.sender] = 0;
-        (bool success, ) = msg.sender.call{value: withdrawableFund}("");
+        (bool success,) = msg.sender.call{value: withdrawableFund}("");
         if (!success) revert TransferFailed();
     }
 
     /// @inheritdoc IRollup
-    function createAssertion(
-        bytes32 vmHash,
-        uint256 inboxSize
-    ) external override stakedOnly {
+    function createAssertion(bytes32 vmHash, uint256 inboxSize) external override stakedOnly {
         uint256 parentID = stakers[msg.sender].assertionID;
         Assertion storage parent = assertions[parentID];
         // Require that enough time has passed since the last assertion.
@@ -311,23 +290,18 @@ contract Rollup is RollupBase {
         // Initialize assertion.
         lastCreatedAssertionID++;
         emit AssertionCreated(lastCreatedAssertionID, msg.sender, vmHash);
-        createAssertionHelper(
-            lastCreatedAssertionID,
-            vmHash,
-            inboxSize,
-            parentID,
-            newAssertionDeadline()
-        );
+        createAssertionHelper(lastCreatedAssertionID, vmHash, inboxSize, parentID, newAssertionDeadline());
 
         // Update stake.
         stakeOnAssertion(msg.sender, lastCreatedAssertionID);
     }
 
     /// @inheritdoc IRollup
-    function challengeAssertion(
-        address[2] calldata players,
-        uint256[2] calldata assertionIDs
-    ) external override returns (address) {
+    function challengeAssertion(address[2] calldata players, uint256[2] calldata assertionIDs)
+        external
+        override
+        returns (address)
+    {
         uint256 defenderAssertionID = assertionIDs[0];
         uint256 parentID = assertions[defenderAssertionID].parent;
         {
@@ -398,10 +372,7 @@ contract Rollup is RollupBase {
         // removeOldZombies();
 
         // (4) all stakers are staked on the block.
-        if (
-            lastUnresolved.numStakers !=
-            countStakedZombies(lastUnresolvedID) + numStakers
-        ) {
+        if (lastUnresolved.numStakers != countStakedZombies(lastUnresolvedID) + numStakers) {
             revert NotAllStaked();
         }
 
@@ -413,17 +384,13 @@ contract Rollup is RollupBase {
     }
 
     /// @inheritdoc IRollup
-    function rejectFirstUnresolvedAssertion(
-        address stakerAddress
-    ) external override {
+    function rejectFirstUnresolvedAssertion(address stakerAddress) external override {
         if (lastResolvedAssertionID >= lastCreatedAssertionID) {
             revert NoUnresolvedAssertion();
         }
 
         uint256 firstUnresolvedAssertionID = lastResolvedAssertionID + 1;
-        Assertion storage firstUnresolvedAssertion = assertions[
-            firstUnresolvedAssertionID
-        ];
+        Assertion storage firstUnresolvedAssertion = assertions[firstUnresolvedAssertionID];
 
         // First case - parent of first unresolved is last confirmed (`if` condition below). e.g.
         // [1] <- [3]           | valid chain ([1] is last confirmed, [3] is stakerAddress's unresolved assertion)
@@ -446,15 +413,10 @@ contract Rollup is RollupBase {
             // - stakerAddress is indeed a staker
             requireStaked(stakerAddress);
             // - staker's assertion can't be a ancestor of firstUnresolved (because staker's assertion is also unresolved)
-            if (
-                stakers[stakerAddress].assertionID < firstUnresolvedAssertionID
-            ) {
+            if (stakers[stakerAddress].assertionID < firstUnresolvedAssertionID) {
                 revert AssertionAlreadyResolved();
             }
-            AssertionState
-                storage firstUnresolvedAssertionState = assertionState[
-                    firstUnresolvedAssertionID
-                ];
+            AssertionState storage firstUnresolvedAssertionState = assertionState[firstUnresolvedAssertionID];
             // - staker's assertion can't be a descendant of firstUnresolved (because staker has never staked on firstUnresolved)
             if (firstUnresolvedAssertionState.stakers[stakerAddress]) {
                 revert StakerStakedOnTarget();
@@ -463,10 +425,7 @@ contract Rollup is RollupBase {
 
             // 1c. no staker is staked on this assertion
             // removeOldZombies();
-            if (
-                firstUnresolvedAssertion.numStakers !=
-                countStakedZombies(firstUnresolvedAssertionID)
-            ) {
+            if (firstUnresolvedAssertion.numStakers != countStakedZombies(firstUnresolvedAssertionID)) {
                 revert StakersPresent();
             }
         }
@@ -478,10 +437,7 @@ contract Rollup is RollupBase {
     }
 
     /// @inheritdoc IChallengeResultReceiver
-    function completeChallenge(
-        address winner,
-        address loser
-    ) external override {
+    function completeChallenge(address winner, address loser) external override {
         address challenge = getChallenge(winner, loser);
         if (msg.sender != challenge) {
             revert NotChallengeManager(msg.sender, challenge);
@@ -518,10 +474,7 @@ contract Rollup is RollupBase {
      * @param stakerAddress Address of existing staker.
      * @param assertionID ID of existing assertion to stake on.
      */
-    function stakeOnAssertion(
-        address stakerAddress,
-        uint256 assertionID
-    ) private {
+    function stakeOnAssertion(address stakerAddress, uint256 assertionID) private {
         stakers[stakerAddress].assertionID = assertionID;
         assertions[assertionID].numStakers++;
         assertionState[assertionID].stakers[stakerAddress] = true;
@@ -576,10 +529,7 @@ contract Rollup is RollupBase {
      * @param staker2Address Address of the second staker
      * @return Address of the challenge that the two stakers are in
      */
-    function getChallenge(
-        address staker1Address,
-        address staker2Address
-    ) private view returns (address) {
+    function getChallenge(address staker1Address, address staker2Address) private view returns (address) {
         Staker storage staker1 = stakers[staker1Address];
         Staker storage staker2 = stakers[staker2Address];
         address challenge = staker1.currentChallenge;
@@ -617,9 +567,7 @@ contract Rollup is RollupBase {
      * @param assertionID The assertion on which to count staked zombies
      * @return The number of zombies staked on the assertion
      */
-    function countStakedZombies(
-        uint256 assertionID
-    ) private view returns (uint256) {
+    function countStakedZombies(uint256 assertionID) private view returns (uint256) {
         uint256 numStakedZombies = 0;
         for (uint256 i = 0; i < zombies.length; i++) {
             if (assertionState[assertionID].stakers[zombies[i].stakerAddress]) {

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -165,6 +165,7 @@ contract Rollup is RollupBase {
             revert InvalidConfigChange();
         }
         daProvider = IDAProvider(newDAProvider);
+        emit ConfigChanged();
     }
 
     /// @inheritdoc IRollup
@@ -173,6 +174,7 @@ contract Rollup is RollupBase {
             revert InvalidConfigChange();
         }
         confirmationPeriod = newPeriod;
+        emit ConfigChanged();
     }
 
     /// @inheritdoc IRollup
@@ -181,6 +183,7 @@ contract Rollup is RollupBase {
             revert InvalidConfigChange();
         }
         challengePeriod = newPeriod;
+        emit ConfigChanged();
     }
 
     /// @inheritdoc IRollup
@@ -189,6 +192,7 @@ contract Rollup is RollupBase {
             revert InvalidConfigChange();
         }
         minimumAssertionPeriod = newPeriod;
+        emit ConfigChanged();
     }
 
     /// @inheritdoc IRollup
@@ -197,6 +201,7 @@ contract Rollup is RollupBase {
             revert InvalidConfigChange();
         }
         baseStakeAmount = newAmount;
+        emit ConfigChanged();
     }
 
     /// @inheritdoc IRollup

--- a/contracts/src/challenge/SymChallenge.sol
+++ b/contracts/src/challenge/SymChallenge.sol
@@ -61,8 +61,8 @@ contract SymChallenge is ChallengeBase, ISymChallenge {
      * @param _verifier Address of the verifier contract.
      * @param _daProvider DA provider.
      * @param _resultReceiver Address of contract that will receive the outcome (via callback `completeChallenge`).
-     * @param _startStateHash Bisection root being challenged.
-     * @param _endStateHash Bisection root being challenged.
+     * @param _startStateHash Commitment to agreed-upon start state.
+     * @param _endStateHash Commitment to disagreed-upon end state being challenged.
      */
     function initialize(
         address _defender,
@@ -94,6 +94,7 @@ contract SymChallenge is ChallengeBase, ISymChallenge {
         challengerTimeLeft = challengePeriod;
     }
 
+    // TODO: use minimum of challenger/defender's proposed numSteps.
     function initializeChallengeLength(uint256 _numSteps) external override onlyOnTurn {
         if (bisectionHash != 0) {
             revert AlreadyInitialized();


### PR DESCRIPTION
Allow `Rollup.sol` to be reconfigured without upgrading the contract when possible. Emits a `ConfigChanged` event when a config param is successfully changed.