### PR TITLE
Avoid validating assertions before committing them locally

### DIFF
--- a/clients/geth/specular/rollup/services/validator/validator.go
+++ b/clients/geth/specular/rollup/services/validator/validator.go
@@ -214,11 +214,7 @@ func (v *Validator) validationLoop(ctx context.Context) {
 					continue
 				}
 				currentAssertion = assertion
-				err = validateCurrentAssertion()
-				if err != nil {
-					// TODO: error handling instead of panic
-					log.Crit("UNHANDLED: Can't validate assertion, validator state corrupted", "err", err)
-				}
+				// assertion is now pending and will be validated once the batch is committed
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
# Goals of PR

Core changes:

The current validator is throwing `errAssertionOverflowedLocalInbox` when validating. 

This is happening because there is an event on `assertionEventCh` (caused by the sequencer creating an on chain assertion) which triggers a validation of the assertion before the validator has committed the new batch locally.

The proposed solution is to leave the assertion pending after the `assertionEventCh` event and only validate them once the batch is committed locally.