### PR TITLE
standard bridge unit tests

### DIFF
--- a/contracts/test/bridge/Common.t.sol
+++ b/contracts/test/bridge/Common.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing utilities
+import {Test, StdUtils} from "forge-std/Test.sol";
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {L1Oracle} from "../../src/bridge/L1Oracle.sol";
+import {L1Portal} from "../../src/bridge/L1Portal.sol";
+import {L2Portal} from "../../src/bridge/L2Portal.sol";
+import {L1StandardBridge} from "../../src/bridge/L1StandardBridge.sol";
+import {L2StandardBridge} from "../../src/bridge/L2StandardBridge.sol";
+import {MintableERC20} from "../../src/bridge/mintable/MintableERC20.sol";
+import {MintableERC20Factory} from "../../src/bridge/mintable/MintableERC20Factory.sol";
+
+contract UUPSProxy is ERC1967Proxy {
+    constructor(address _implementation, bytes memory _data) ERC1967Proxy(_implementation, _data) {}
+}
+
+contract CommonTest is Test {
+    address alice = address(1);
+    address bob = address(2);
+
+    function setUp() public virtual {
+        vm.deal(alice, 1 << 16);
+        vm.deal(bob, 1 << 16);
+    }
+}
+
+contract L1Oracle_Initializer is CommonTest {
+    address sequencerAddress = address(8);
+    address l1OracleAddress = address(16);
+
+    L1Oracle oracle;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        vm.etch(l1OracleAddress, address(new L1Oracle()).code);
+        vm.label(l1OracleAddress, "L1Oracle");
+
+        oracle = L1Oracle(l1OracleAddress);
+        oracle.initialize(sequencerAddress);
+    }
+}
+
+contract Portal_Initializer is L1Oracle_Initializer {
+    address payable l1PortalAddress;
+    address payable l2PortalAddress;
+
+    L1Portal l1Portal;
+    L2Portal l2Portal;
+
+    UUPSProxy l1PortalProxy;
+    UUPSProxy l2PortalProxy;
+
+    event DepositInitiated(
+        uint256 indexed nonce,
+        address indexed sender,
+        address indexed target,
+        uint256 value,
+        uint256 gasLimit,
+        bytes data,
+        bytes32 depositHash
+    );
+
+    event WithdrawalInitiated(
+        uint256 indexed nonce,
+        address indexed sender,
+        address indexed target,
+        uint256 value,
+        uint256 gasLimit,
+        bytes data,
+        bytes32 withdrawalHash
+    );
+
+    event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        l1PortalProxy = new UUPSProxy(address(new L1Portal()), "");
+        l1PortalAddress = payable(address(l1PortalProxy));
+        vm.label(l1PortalAddress, "L1Portal");
+        l1Portal = L1Portal(l1PortalAddress);
+
+        // dummy rollup address
+        l1Portal.initialize(address(42));
+
+        l2PortalProxy = new UUPSProxy(address(new L2Portal()), "");
+        l2PortalAddress = payable(address(l2PortalProxy));
+        vm.label(l2PortalAddress, "L2Portal");
+        l2Portal = L2Portal(l2PortalAddress);
+
+        l1Portal.setL2PortalAddress(l2PortalAddress);
+        l2Portal.initialize(l1OracleAddress, l1PortalAddress);
+    }
+}
+
+contract StandardBridge_Initializer is Portal_Initializer {
+    address payable l1StandardBridgeAddress = payable(address(128));
+    address payable l2StandardBridgeAddress = payable(address(256));
+
+    L1StandardBridge l1StandardBridge;
+    L2StandardBridge l2StandardBridge;
+
+    MintableERC20Factory l1TokenFactory;
+    MintableERC20Factory l2TokenFactory;
+    ERC20 l1Token;
+    ERC20 badL1Token;
+    MintableERC20 l2Token;
+    ERC20 nativeL2Token;
+    ERC20 badL2Token;
+    MintableERC20 remoteL1Token;
+
+    event ETHBridgeInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
+
+    event ERC20BridgeInitiated(
+        address indexed localToken,
+        address indexed remoteToken,
+        address indexed from,
+        address to,
+        uint256 amount,
+        bytes extraData
+    );
+
+    event ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
+
+    event ERC20BridgeFinalized(
+        address indexed localToken,
+        address indexed remoteToken,
+        address indexed from,
+        address to,
+        uint256 amount,
+        bytes extraData
+    );
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // TODO: deploy StandardBridge contracts behind proxy
+        vm.etch(l1StandardBridgeAddress, address(new L1StandardBridge()).code);
+        vm.label(l1StandardBridgeAddress, "L1StandardBridge");
+
+        l1StandardBridge = L1StandardBridge(payable(l1StandardBridgeAddress));
+        l1StandardBridge.initialize(l1PortalAddress, l2StandardBridgeAddress);
+
+        vm.etch(l2StandardBridgeAddress, address(new L2StandardBridge()).code);
+        vm.label(l2StandardBridgeAddress, "L2StandardBridge");
+
+        l2StandardBridge = L2StandardBridge(l2StandardBridgeAddress);
+        l2StandardBridge.initialize(l2PortalAddress, l1StandardBridgeAddress);
+
+        // depoly ERC20 tokens for testing
+        l2TokenFactory = new MintableERC20Factory(
+            l2StandardBridgeAddress
+        );
+
+        l1Token = new ERC20("Native L1 Token", "L1T");
+
+        l2Token = MintableERC20(l2TokenFactory.createMintableERC20(address(l1Token), "Remote L1 Token", "rL1T"));
+
+        badL2Token = MintableERC20(l2TokenFactory.createMintableERC20(address(1), "Bad L2 Token", "bL2T"));
+    }
+}

--- a/contracts/test/bridge/L1StandardBridge.t.sol
+++ b/contracts/test/bridge/L1StandardBridge.t.sol
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing utilities
+import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {StandardBridge_Initializer} from "./Common.t.sol";
+
+// Target contract dependencies
+import {Types} from "../../src/libraries/Types.sol";
+import {StandardBridge} from "../../src/bridge/StandardBridge.sol";
+import {L1StandardBridge} from "../../src/bridge/L1StandardBridge.sol";
+import {L2StandardBridge} from "../../src/bridge/L2StandardBridge.sol";
+import {L1Portal} from "../../src/bridge/L1Portal.sol";
+import {AddressAliasHelper} from "../../src/vendor/AddressAliasHelper.sol";
+
+contract L1StandardBridge_Getter_Test is StandardBridge_Initializer {
+    /// @dev Test that the accessors return the correct initialized values.
+    function test_getters_succeeds() external view {
+        assert(l1StandardBridge.L1_PORTAL() == l1Portal);
+        assert(l1StandardBridge.PORTAL_ADDRESS() == l1PortalAddress);
+        assert(l1StandardBridge.OTHER_BRIDGE() == l2StandardBridge);
+    }
+}
+
+contract L1StandardBridge_Receive_Test is StandardBridge_Initializer {
+    /// @dev Tests receive bridges ETH successfully.
+    function test_receive_succeeds() external {
+        assertEq(l1PortalAddress.balance, 0);
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, alice, 100, hex"");
+
+        vm.expectCall(
+            l1PortalAddress,
+            abi.encodeWithSelector(
+                l1Portal.initiateDeposit.selector,
+                l2StandardBridgeAddress,
+                200_000,
+                abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 100, "")
+            )
+        );
+
+        vm.prank(alice, alice);
+        (bool success,) = l1StandardBridgeAddress.call{value: 100}(hex"");
+        assertEq(success, true);
+        assertEq(l1PortalAddress.balance, 100);
+    }
+}
+
+contract PreBridgeETH is StandardBridge_Initializer {
+    /// @dev Asserts the expected calls and events for bridging ETH
+    function _preBridgeETH() internal {
+        assertEq(l1StandardBridgeAddress.balance, 0);
+
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 500, hex"dead");
+
+        vm.expectCall(
+            l1StandardBridgeAddress, 500, abi.encodeWithSelector(StandardBridge.bridgeETH.selector, 50000, hex"dead")
+        );
+
+        vm.expectCall(
+            l1PortalAddress,
+            500,
+            abi.encodeWithSelector(L1Portal.initiateDeposit.selector, l2StandardBridgeAddress, 50000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, alice, 500, hex"dead");
+
+        uint256 nonce = l1Portal.nonce();
+        emit DepositInitiated(nonce, alice, alice, 500, 5000, hex"dead", "");
+
+        vm.prank(alice, alice);
+    }
+}
+
+contract L1StandardBridge_DepositETH_Test is PreBridgeETH {
+    /// @dev Tests that depositing ETH succeeds.
+    ///      Emits ETHDepositInitiated and ETHBridgeInitiated events.
+    function test_depositETH_succeeds() external {
+        _preBridgeETH();
+        l1StandardBridge.bridgeETH{value: 500}(50000, hex"dead");
+        assertEq(l1PortalAddress.balance, 500);
+    }
+}
+
+contract PreBridgeETHTo is StandardBridge_Initializer {
+    /// @dev Asserts the expected calls and events for bridging ETH to a different address
+    function _preBridgeETHTo() internal {
+        assertEq(l1StandardBridgeAddress.balance, 0);
+
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, bob, 600, hex"dead");
+
+        vm.expectCall(
+            l1StandardBridgeAddress,
+            600,
+            abi.encodeWithSelector(StandardBridge.bridgeETHTo.selector, bob, 60000, hex"dead")
+        );
+
+        vm.expectCall(
+            l1PortalAddress,
+            600,
+            abi.encodeWithSelector(L1Portal.initiateDeposit.selector, l2StandardBridgeAddress, 60000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, bob, 600, hex"dead");
+
+        uint256 nonce = l1Portal.nonce();
+        vm.expectEmit(true, true, true, true, l1PortalAddress);
+        emit DepositInitiated(
+            nonce,
+            AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress),
+            l2StandardBridgeAddress,
+            600,
+            60000,
+            message,
+            hex"efdfee2f5058687ebc6d0c1f711885c5cf1f24aa32933d67b97e8c49bccabd00"
+        );
+
+        vm.prank(alice, alice);
+    }
+}
+
+contract L1StandardBridge_DepositETHTo_Test is PreBridgeETHTo {
+    /// @dev Tests that depositing ETH to a different address succeeds.
+    ///      Emits ETHDepositInitiated event.
+    function test_depositETHTo_succeeds() external {
+        _preBridgeETHTo();
+        l1StandardBridge.bridgeETHTo{value: 600}(bob, 60000, hex"dead");
+        assertEq(address(l1PortalAddress).balance, 600);
+    }
+}
+
+contract L1StandardBridge_DepositERC20_Test is StandardBridge_Initializer {
+    using stdStorage for StdStorage;
+
+    /// @dev Tests that depositing ERC20 to the bridge succeeds.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20DepositInitiated event.
+    function test_depositERC20_succeeds() external {
+        uint256 nonce = l1Portal.nonce();
+
+        // Deal Alice's ERC20 State
+        deal(address(l1Token), alice, 100000, true);
+        vm.prank(alice);
+        l1Token.approve(l1StandardBridgeAddress, type(uint256).max);
+
+        // The L1Bridge should transfer alice's tokens to itself
+        vm.expectCall(
+            address(l1Token), abi.encodeWithSelector(ERC20.transferFrom.selector, alice, l1StandardBridgeAddress, 100)
+        );
+
+        bytes memory message = abi.encodeWithSelector(
+            StandardBridge.finalizeBridgeERC20.selector, address(l2Token), address(l1Token), alice, alice, 100, hex""
+        );
+
+        // the L1 bridge should call L1Portal.initiateDeposit
+        vm.expectCall(
+            l1PortalAddress,
+            abi.encodeWithSelector(L1Portal.initiateDeposit.selector, l2StandardBridgeAddress, 10000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ERC20BridgeInitiated(address(l1Token), address(l2Token), alice, alice, 100, hex"");
+        vm.expectEmit(true, true, true, true, l1PortalAddress);
+        emit DepositInitiated(
+            nonce,
+            AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress),
+            l2StandardBridgeAddress,
+            0,
+            10000,
+            message,
+            hex"eff2698675bc67cd2fec9b070280d12442b0156ae58f133f242b550c81b0c946"
+        );
+
+        vm.prank(alice);
+        l1StandardBridge.bridgeERC20(address(l1Token), address(l2Token), 100, 10000, hex"");
+        assertEq(l1StandardBridge.deposits(address(l1Token), address(l2Token)), 100);
+    }
+}
+
+contract L1StandardBridge_DepositERC20To_Test is StandardBridge_Initializer {
+    /// @dev Tests that depositing ERC20 to the bridge succeeds when
+    ///      sent to a different address.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20DepositInitiated event.
+    function test_depositERC20To_succeeds() external {
+        uint256 nonce = l1Portal.nonce();
+
+        // Deal Alice's ERC20 State
+        deal(address(l1Token), alice, 100000, true);
+        vm.prank(alice);
+        l1Token.approve(l1StandardBridgeAddress, type(uint256).max);
+
+        // The L1Bridge should transfer alice's tokens to itself
+        vm.expectCall(
+            address(l1Token), abi.encodeWithSelector(ERC20.transferFrom.selector, alice, l1StandardBridgeAddress, 100)
+        );
+
+        bytes memory message = abi.encodeWithSelector(
+            StandardBridge.finalizeBridgeERC20.selector, address(l2Token), address(l1Token), alice, bob, 100, hex""
+        );
+
+        // the L1 bridge should call L1Portal.initiateDeposit
+        vm.expectCall(
+            l1PortalAddress,
+            abi.encodeWithSelector(L1Portal.initiateDeposit.selector, l2StandardBridgeAddress, 10000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ERC20BridgeInitiated(address(l1Token), address(l2Token), alice, bob, 100, hex"");
+        vm.expectEmit(true, true, true, true, l1PortalAddress);
+        emit DepositInitiated(
+            nonce,
+            AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress),
+            l2StandardBridgeAddress,
+            0,
+            10000,
+            message,
+            hex"e4b2e5e4417057999367136a09bb17ce400dd06984e78bb926776419fd15cfb3"
+        );
+
+        vm.prank(alice);
+        l1StandardBridge.bridgeERC20To(address(l1Token), address(l2Token), bob, 100, 10000, hex"");
+        assertEq(l1StandardBridge.deposits(address(l1Token), address(l2Token)), 100);
+    }
+}
+
+contract L1StandardBridge_FinalizeETHWithdrawal_Test is StandardBridge_Initializer {
+    /// @dev Tests that finalizing an ETH withdrawal succeeds.
+    ///      Emits ETHWithdrawalFinalized event.
+    ///      Only callable by the L2 bridge.
+    function test_finalizeETHWithdrawal_succeeds() external {
+        uint256 aliceBalance = alice.balance;
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ETHBridgeFinalized(alice, alice, 100, hex"");
+
+        vm.expectCall(alice, hex"");
+
+        //address l2StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l2StandardBridgeAddress);
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+
+        vm.deal(l1PortalAddress, 100);
+        vm.prank(l1PortalAddress);
+        l1StandardBridge.finalizeBridgeETH{value: 100}(alice, alice, 100, hex"");
+
+        assertEq(l1PortalAddress.balance, 0);
+        assertEq(aliceBalance + 100, alice.balance);
+    }
+}
+
+contract L1StandardBridge_FinalizeERC20Withdrawal_Test is StandardBridge_Initializer {
+    using stdStorage for StdStorage;
+
+    /// @dev Tests that finalizing an ERC20 withdrawal succeeds.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20WithdrawalFinalized event.
+    ///      Only callable by the L2 bridge.
+    function test_finalizeERC20Withdrawal_succeeds() external {
+        deal(address(l1Token), l1StandardBridgeAddress, 100, true);
+
+        uint256 slot = stdstore.target(l1StandardBridgeAddress).sig("deposits(address,address)").with_key(
+            address(l1Token)
+        ).with_key(address(l2Token)).find();
+
+        // Give the L1 bridge some ERC20 tokens
+        vm.store(l1StandardBridgeAddress, bytes32(slot), bytes32(uint256(100)));
+        assertEq(l1StandardBridge.deposits(address(l1Token), address(l2Token)), 100);
+
+        vm.expectEmit(true, true, true, true, l1StandardBridgeAddress);
+        emit ERC20BridgeFinalized(address(l1Token), address(l2Token), alice, alice, 100, hex"");
+
+        vm.expectCall(address(l1Token), abi.encodeWithSelector(ERC20.transfer.selector, alice, 100));
+
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+
+        vm.prank(l1PortalAddress);
+        l1StandardBridge.finalizeBridgeERC20(address(l1Token), address(l2Token), alice, alice, 100, hex"");
+
+        assertEq(l1Token.balanceOf(l1StandardBridgeAddress), 0);
+        assertEq(l1Token.balanceOf(address(alice)), 100);
+    }
+}
+
+contract L1StandardBridge_FinalizeERC20Withdrawal_TestFail is StandardBridge_Initializer {
+    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
+    function test_finalizeERC20Withdrawal_notMessenger_reverts() external {
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+        vm.prank(address(28));
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l1StandardBridge.finalizeBridgeERC20(address(l1Token), address(l2Token), alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
+    function test_finalizeERC20Withdrawal_notOtherBridge_reverts() external {
+        vm.mockCall(l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(address(28)));
+        vm.prank(l1PortalAddress);
+
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l1StandardBridge.finalizeBridgeERC20(address(l1Token), address(l2Token), alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the amount is incorrect.
+    function test_finalizeBridgeETH_incorrectValue_reverts() external {
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+
+        vm.deal(l1PortalAddress, 100);
+        vm.prank(l1PortalAddress);
+
+        vm.expectRevert("StandardBridge: amount sent does not match amount required");
+        l1StandardBridge.finalizeBridgeETH{value: 50}(alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the destination is the L1 bridge.
+    function test_finalizeBridgeETH_sendToSelf_reverts() external {
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+
+        vm.deal(l1PortalAddress, 100);
+        vm.prank(l1PortalAddress);
+
+        vm.expectRevert("StandardBridge: cannot send to self");
+        l1StandardBridge.finalizeBridgeETH{value: 100}(alice, l1StandardBridgeAddress, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the destination is the portal.
+    function test_finalizeBridgeETH_sendToPortal_reverts() external {
+        vm.mockCall(
+            l1PortalAddress, abi.encodeWithSelector(l1Portal.l2Sender.selector), abi.encode(l2StandardBridgeAddress)
+        );
+
+        vm.deal(l1PortalAddress, 100);
+        vm.prank(l1PortalAddress);
+
+        vm.expectRevert("StandardBridge: cannot send to portal");
+        l1StandardBridge.finalizeBridgeETH{value: 100}(alice, l1PortalAddress, 100, hex"");
+    }
+}

--- a/contracts/test/bridge/L2StandardBridge.t.sol
+++ b/contracts/test/bridge/L2StandardBridge.t.sol
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing utilities
+import {Test, stdStorage, StdStorage} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {StandardBridge_Initializer} from "./Common.t.sol";
+
+// Target contract dependencies
+import {Types} from "../../src/libraries/Types.sol";
+import {StandardBridge} from "../../src/bridge/StandardBridge.sol";
+import {L1StandardBridge} from "../../src/bridge/L1StandardBridge.sol";
+import {L2StandardBridge} from "../../src/bridge/L2StandardBridge.sol";
+import {L2Portal} from "../../src/bridge/L2Portal.sol";
+import {AddressAliasHelper} from "../../src/vendor/AddressAliasHelper.sol";
+import {MintableERC20} from "../../src/bridge/mintable/MintableERC20.sol";
+
+contract L2StandardBridge_Getter_Test is StandardBridge_Initializer {
+    /// @dev Test that the accessors return the correct initialized values.
+    function test_getters_succeeds() external view {
+        assert(l2StandardBridge.L2_PORTAL() == l2Portal);
+        assert(l2StandardBridge.PORTAL_ADDRESS() == l2PortalAddress);
+        assert(l2StandardBridge.OTHER_BRIDGE() == l1StandardBridge);
+    }
+}
+
+contract L2StandardBridge_Receive_Test is StandardBridge_Initializer {
+    /// @dev Tests receive bridges ETH successfully.
+    function test_receive_succeeds() external {
+        assertEq(l2PortalAddress.balance, 0);
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, alice, 100, hex"");
+
+        vm.expectCall(
+            l2PortalAddress,
+            abi.encodeWithSelector(
+                l2Portal.initiateWithdrawal.selector,
+                l1StandardBridgeAddress,
+                200_000,
+                abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 100, "")
+            )
+        );
+
+        vm.prank(alice, alice);
+        (bool success,) = l2StandardBridgeAddress.call{value: 100}(hex"");
+        assertEq(success, true);
+        assertEq(l2PortalAddress.balance, 100);
+    }
+}
+
+contract PreBridgeETH is StandardBridge_Initializer {
+    /// @dev Asserts the expected calls and events for bridging ETH
+    function _preBridgeETH() internal {
+        assertEq(l2StandardBridgeAddress.balance, 0);
+
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, alice, 500, hex"dead");
+
+        vm.expectCall(
+            l2StandardBridgeAddress, 500, abi.encodeWithSelector(StandardBridge.bridgeETH.selector, 50000, hex"dead")
+        );
+
+        vm.expectCall(
+            l2PortalAddress,
+            500,
+            abi.encodeWithSelector(L2Portal.initiateWithdrawal.selector, l1StandardBridgeAddress, 50000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, alice, 500, hex"dead");
+
+        uint256 nonce = l2Portal.nonce();
+        vm.expectEmit(true, true, true, true, l2PortalAddress);
+        emit WithdrawalInitiated(
+            nonce,
+            l2StandardBridgeAddress,
+            l1StandardBridgeAddress,
+            500,
+            50000,
+            message,
+            hex"0fe9cd7a56e0225f948814cb43e17f4486d74a20d8e9196663286dcc65a6d4df"
+        );
+
+        vm.prank(alice, alice);
+    }
+}
+
+contract L2StandardBridge_DepositETH_Test is PreBridgeETH {
+    /// @dev Tests that depositing ETH succeeds.
+    ///      Emits ETHDepositInitiated and ETHBridgeInitiated events.
+    function test_depositETH_succeeds() external {
+        _preBridgeETH();
+        l2StandardBridge.bridgeETH{value: 500}(50000, hex"dead");
+        assertEq(l2PortalAddress.balance, 500);
+    }
+}
+
+contract PreBridgeETHTo is StandardBridge_Initializer {
+    /// @dev Asserts the expected calls and events for bridging ETH to a different address
+    function _preBridgeETHTo() internal {
+        assertEq(l2StandardBridgeAddress.balance, 0);
+
+        bytes memory message =
+            abi.encodeWithSelector(StandardBridge.finalizeBridgeETH.selector, alice, bob, 600, hex"dead");
+
+        vm.expectCall(
+            l2StandardBridgeAddress,
+            600,
+            abi.encodeWithSelector(StandardBridge.bridgeETHTo.selector, bob, 60000, hex"dead")
+        );
+
+        vm.expectCall(
+            l2PortalAddress,
+            600,
+            abi.encodeWithSelector(L2Portal.initiateWithdrawal.selector, l1StandardBridgeAddress, 60000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ETHBridgeInitiated(alice, bob, 600, hex"dead");
+
+        uint256 nonce = l1Portal.nonce();
+        vm.expectEmit(true, true, true, true, l2PortalAddress);
+        emit WithdrawalInitiated(
+            nonce,
+            l2StandardBridgeAddress,
+            l1StandardBridgeAddress,
+            600,
+            60000,
+            message,
+            hex"491b330b394afd698ba45908eaccd29934dac0b423d621047e0035cf2831c179"
+        );
+
+        vm.prank(alice, alice);
+    }
+}
+
+contract L2StandardBridge_DepositETHTo_Test is PreBridgeETHTo {
+    /// @dev Tests that depositing ETH to a different address succeeds.
+    ///      Emits ETHDepositInitiated event.
+    function test_depositETHTo_succeeds() external {
+        _preBridgeETHTo();
+        l2StandardBridge.bridgeETHTo{value: 600}(bob, 60000, hex"dead");
+        assertEq(address(l2PortalAddress).balance, 600);
+    }
+}
+
+contract L2StandardBridge_DepositERC20_Test is StandardBridge_Initializer {
+    using stdStorage for StdStorage;
+
+    /// @dev Tests that depositing ERC20 to the bridge succeeds.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20DepositInitiated event.
+    function test_depositERC20_succeeds() external {
+        uint256 nonce = l2Portal.nonce();
+
+        // Deal Alice's ERC20 State
+        deal(address(l2Token), alice, 200000, true);
+        vm.prank(alice);
+        l2Token.approve(l2StandardBridgeAddress, type(uint256).max);
+
+        uint256 slot = stdstore.target(l2StandardBridgeAddress).sig("deposits(address,address)").with_key(
+            address(l2Token)
+        ).with_key(address(l1Token)).find();
+
+        // Give the L1 bridge some ERC20 tokens
+        vm.store(l2StandardBridgeAddress, bytes32(slot), bytes32(uint256(200)));
+        assertEq(l2StandardBridge.deposits(address(l2Token), address(l1Token)), 200);
+
+        bytes memory message = abi.encodeWithSelector(
+            StandardBridge.finalizeBridgeERC20.selector, address(l1Token), address(l2Token), alice, alice, 200, hex""
+        );
+
+        vm.expectCall(
+            l2PortalAddress,
+            abi.encodeWithSelector(L2Portal.initiateWithdrawal.selector, l1StandardBridgeAddress, 20000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ERC20BridgeInitiated(address(l2Token), address(l1Token), alice, alice, 200, hex"");
+
+        vm.expectEmit(true, true, true, false, l2PortalAddress);
+        emit WithdrawalInitiated(
+            nonce,
+            l2StandardBridgeAddress,
+            l1StandardBridgeAddress,
+            0,
+            20000,
+            message,
+            hex"9c1138905230c0a8e24b2ee190fe794850ce1ae637a682f4f5ef9a07c3ac405e"
+        );
+
+        vm.prank(alice);
+        l2StandardBridge.bridgeERC20(address(l2Token), address(l1Token), 200, 20000, hex"");
+        assertEq(l2StandardBridge.deposits(address(l2Token), address(l1Token)), 200);
+    }
+}
+
+contract L2StandardBridge_DepositERC20To_Test is StandardBridge_Initializer {
+    using stdStorage for StdStorage;
+
+    /// @dev Tests that depositing ERC20 to the bridge succeeds when
+    ///      sent to a different address.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20DepositInitiated event.
+    function test_depositERC20_succeeds() external {
+        uint256 nonce = l2Portal.nonce();
+
+        // Deal Alice's ERC20 State
+        deal(address(l2Token), alice, 200000, true);
+        vm.prank(alice);
+        l2Token.approve(l2StandardBridgeAddress, type(uint256).max);
+
+        uint256 slot = stdstore.target(l2StandardBridgeAddress).sig("deposits(address,address)").with_key(
+            address(l2Token)
+        ).with_key(address(l1Token)).find();
+
+        // Give the L1 bridge some ERC20 tokens
+        vm.store(l2StandardBridgeAddress, bytes32(slot), bytes32(uint256(200)));
+        assertEq(l2StandardBridge.deposits(address(l2Token), address(l1Token)), 200);
+
+        bytes memory message = abi.encodeWithSelector(
+            StandardBridge.finalizeBridgeERC20.selector, address(l1Token), address(l2Token), alice, bob, 200, hex""
+        );
+
+        vm.expectCall(
+            l2PortalAddress,
+            abi.encodeWithSelector(L2Portal.initiateWithdrawal.selector, l1StandardBridgeAddress, 20000, message)
+        );
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ERC20BridgeInitiated(address(l2Token), address(l1Token), alice, bob, 200, hex"");
+
+        vm.expectEmit(true, true, true, true, l2PortalAddress);
+        emit WithdrawalInitiated(
+            nonce,
+            l2StandardBridgeAddress,
+            l1StandardBridgeAddress,
+            0,
+            20000,
+            message,
+            hex"6d93a3300ef9266dec731698398762e2597bde7e691f07d584822b0b43cbf5c6"
+        );
+
+        vm.prank(alice);
+        l2StandardBridge.bridgeERC20To(address(l2Token), address(l1Token), bob, 200, 20000, hex"");
+        assertEq(l2StandardBridge.deposits(address(l2Token), address(l1Token)), 200);
+    }
+}
+
+contract L2StandardBridge_FinalizeETHWithdrawal_Test is StandardBridge_Initializer {
+    /// @dev Tests that finalizing an ETH withdrawal succeeds.
+    ///      Emits ETHWithdrawalFinalized event.
+    ///      Only callable by the L2 bridge.
+    function test_finalizeETHWithdrawal_succeeds() external {
+        uint256 aliceBalance = alice.balance;
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ETHBridgeFinalized(alice, alice, 100, hex"");
+
+        vm.expectCall(alice, hex"");
+
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.deal(l2PortalAddress, 100);
+        vm.prank(l2PortalAddress);
+        l2StandardBridge.finalizeBridgeETH{value: 100}(alice, alice, 100, hex"");
+
+        assertEq(l2PortalAddress.balance, 0);
+        assertEq(aliceBalance + 100, alice.balance);
+    }
+}
+
+contract L2StandardBridge_FinalizeERC20Withdrawal_Test is StandardBridge_Initializer {
+    using stdStorage for StdStorage;
+
+    /// @dev Tests that finalizing an ERC20 withdrawal succeeds.
+    ///      Bridge deposits are updated.
+    ///      Emits ERC20WithdrawalFinalized event.
+    ///      Only callable by the L2 bridge.
+    function test_finalizeERC20Withdrawal_succeeds() external {
+        assertEq(l2Token.balanceOf(l2StandardBridgeAddress), 0);
+
+        uint256 slot = stdstore.target(l2StandardBridgeAddress).sig("deposits(address,address)").with_key(
+            address(l2Token)
+        ).with_key(address(l1Token)).find();
+
+        // Give the L2 bridge some ERC20 tokens
+        vm.store(l2StandardBridgeAddress, bytes32(slot), bytes32(uint256(100)));
+        assertEq(l2StandardBridge.deposits(address(l2Token), address(l1Token)), 100);
+
+        vm.expectEmit(true, true, true, true, l2StandardBridgeAddress);
+        emit ERC20BridgeFinalized(address(l2Token), address(l1Token), alice, alice, 100, hex"");
+
+        vm.expectCall(address(l2Token), abi.encodeWithSelector(MintableERC20.mint.selector, alice, 100));
+
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.prank(l2PortalAddress);
+        l2StandardBridge.finalizeBridgeERC20(address(l2Token), address(l1Token), alice, alice, 100, hex"");
+
+        assertEq(l2Token.balanceOf(l2StandardBridgeAddress), 0);
+        assertEq(l2Token.balanceOf(address(alice)), 100);
+    }
+}
+
+contract L2StandardBridge_FinalizeERC20Withdrawal_TestFail is StandardBridge_Initializer {
+    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
+    function test_finalizeERC20Withdrawal_notMessenger_reverts() external {
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.prank(address(28));
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l2StandardBridge.finalizeBridgeERC20(address(l2Token), address(l1Token), alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing an ERC20 withdrawal reverts if the caller is not the L2 bridge.
+    function test_finalizeERC20Withdrawal_notOtherBridge_reverts() external {
+        vm.mockCall(l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(address(28)));
+        vm.prank(l1PortalAddress);
+
+        vm.expectRevert("StandardBridge: function can only be called from the other bridge");
+        l2StandardBridge.finalizeBridgeERC20(address(l2Token), address(l1Token), alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the amount is incorrect.
+    function test_finalizeBridgeETH_incorrectValue_reverts() external {
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.deal(l2PortalAddress, 100);
+        vm.prank(l2PortalAddress);
+
+        vm.expectRevert("StandardBridge: amount sent does not match amount required");
+        l2StandardBridge.finalizeBridgeETH{value: 50}(alice, alice, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the destination is the L1 bridge.
+    function test_finalizeBridgeETH_sendToSelf_reverts() external {
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.deal(l2PortalAddress, 100);
+        vm.prank(l2PortalAddress);
+
+        vm.expectRevert("StandardBridge: cannot send to self");
+        l2StandardBridge.finalizeBridgeETH{value: 100}(alice, l2StandardBridgeAddress, 100, hex"");
+    }
+
+    /// @dev Tests that finalizing bridged ETH reverts if the destination is the portal.
+    function test_finalizeBridgeETH_sendToPortal_reverts() external {
+        address l1StandardBridgeAlias = AddressAliasHelper.applyL1ToL2Alias(l1StandardBridgeAddress);
+
+        vm.mockCall(
+            l2PortalAddress, abi.encodeWithSelector(l2Portal.l1Sender.selector), abi.encode(l1StandardBridgeAlias)
+        );
+
+        vm.deal(l2PortalAddress, 100);
+        vm.prank(l2PortalAddress);
+
+        vm.expectRevert("StandardBridge: cannot send to portal");
+        l2StandardBridge.finalizeBridgeETH{value: 100}(alice, l2PortalAddress, 100, hex"");
+    }
+}

--- a/contracts/test/bridge/StandardBridge.t.sol
+++ b/contracts/test/bridge/StandardBridge.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {StandardBridge} from "../../src/bridge/StandardBridge.sol";
+import {MintableERC20} from "../../src/bridge/mintable/MintableERC20.sol";
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title StandardBridgeTester
+/// @notice Simple wrapper around the StandardBridge contract that exposes
+///         internal functions so they can be more easily tested directly.
+contract StandardBridgeTester is StandardBridge {
+    constructor(address payable _messenger, address payable _otherBridge) {
+        __StandardBridge_init(_messenger, _otherBridge);
+    }
+
+    modifier onlyOtherBridge() override {
+        _;
+    }
+
+    function isCorrectTokenPair(address _mintableToken, address _otherToken) external view returns (bool) {
+        return _isNonNativeTokenPair(_mintableToken, _otherToken);
+    }
+
+    receive() external payable override {}
+}
+
+/// @title StandardBridge_Stateless_Test
+/// @notice Tests internal functions that require no existing state or contract
+///         interactions with the messenger.
+contract StandardBridge_Stateless_Test is Test {
+    StandardBridgeTester internal bridge;
+    MintableERC20 internal mintable;
+    ERC20 internal erc20;
+
+    function setUp() public {
+        bridge = new StandardBridgeTester({
+            _messenger: payable(address(0)),
+            _otherBridge: payable(address(0))
+        });
+
+        mintable = new MintableERC20({
+            _bridge: address(0),
+            _remoteToken: address(0),
+            _name: "Stonks",
+            _symbol: "STONK"
+        });
+
+        erc20 = new ERC20("Altcoin", "ALT");
+    }
+
+    /// @notice Test coverage of isCorrectTokenPair under different types of
+    ///         tokens.
+    function test_isCorrectTokenPair_succeeds() external {
+        // known to be correct remote token
+        assertTrue(bridge.isCorrectTokenPair(address(mintable), mintable.REMOTE_TOKEN()));
+        // known to be incorrect remote token
+        assertTrue(mintable.REMOTE_TOKEN() != address(0x20));
+        assertFalse(bridge.isCorrectTokenPair(address(mintable), address(0x20)));
+        // A token that doesn't support the mintable interface will revert
+        assertFalse(bridge.isCorrectTokenPair(address(erc20), address(1)));
+    }
+}


### PR DESCRIPTION
# Goals of PR

Core changes:

- adds unit tests for the standard bridge contracts
- the test try to emulate the approach taken by [optimism](https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/test)
- depends on #131
