### PR TITLE
Add Ability to Pause/Unpause Contracts

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -42,8 +42,8 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.8.3",
-    "@openzeppelin/contracts-upgradeable": "^4.8.3",
+    "@openzeppelin/contracts": "^4.9.3",
+    "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "ethereumjs-util": "^7.1.5",
     "glob": "^10.2.3",

--- a/contracts/scripts/pause.ts
+++ b/contracts/scripts/pause.ts
@@ -35,7 +35,8 @@ async function pauseContract(
   const owner = new ethers.Wallet(privateKey, provider);
   const factory = await ethers.getContractFactory(contract, address);
   const c = factory.attach(address);
-  c.pause();
+  const tx = c.pause();
+  await tx.wait();
 }
 
 async function unpauseContract(
@@ -47,7 +48,8 @@ async function unpauseContract(
   const owner = new ethers.Wallet(privateKey, provider);
   const factory = await ethers.getContractFactory(contract, address);
   const c = factory.attach(address);
-  c.unpause();
+  const tx = c.unpause();
+  await tx.wait();
 }
 
 async function pauseContracts() {

--- a/contracts/scripts/pause.ts
+++ b/contracts/scripts/pause.ts
@@ -1,0 +1,86 @@
+import * as ethers from "ethers";
+
+const rollupAddr = process.env.ROLLUP_ADDR;
+const rollupPrKey = process.env.ROLLUP_PRIVATE_KEY;
+
+const sequencerAddr = process.env.SEQUENCER_ADDR;
+const sequencerPrKey = process.env.SEQUENCER_PRIVATE_KEY;
+
+const l1BridgeAddr = process.env.L1_BRIDGE_ADDR;
+const l1BridgePrKey = process.env.L1_BRIDGE_PRIVATE_KEY;
+
+const l1OracleAddr = process.env.L1_ORACLE_ADDR;
+const l1OraclePrKey = process.env.L1_ORACLE_PRIVATE_KEY;
+
+const l1PortalAddr = process.env.L1_PORTAL_ADDR;
+const l1PortalPrKey = process.env.L1_PORTAL_PRIVATE_KEY;
+
+const l2BridgeAddr = process.env.L2_BRIDGE_ADDR;
+const l2PortalAddr = process.env.L2_PORTAL_ADDR;
+
+const faucetAddr = process.env.FAUCET_ADDR;
+
+const l1RPCAddr = process.env.L1_RPC_ADDRESS;
+const l1Provider = new ethers.providers.JsonRpcProvider(l1RPCAddr);
+
+const l2RPCAddr = process.env.L2_RPC_ADDRESS;
+const l2Provider = new ethers.providers.JsonRpcProvider(l2RPCAddr);
+
+async function pauseContract(
+  contract: string,
+  address: string,
+  provider: ethers.providers.JsonRpcProvider,
+  privateKey: string
+) {
+  const owner = new ethers.Wallet(privateKey, provider);
+  const factory = await ethers.getContractFactory(contract, address);
+  const c = factory.attach(address);
+  c.pause();
+}
+
+async function unpauseContract(
+  contract: string,
+  address: string,
+  provider: ethers.providers.JsonRpcProvider,
+  privateKey: string
+) {
+  const owner = new ethers.Wallet(privateKey, provider);
+  const factory = await ethers.getContractFactory(contract, address);
+  const c = factory.attach(address);
+  c.unpause();
+}
+
+async function pauseContracts() {
+  // Pause L1 Contracts
+  pauseContract("Rollup", rollupAddr, l1Provider, rollupPrKey);
+  pauseContract("SequencerInbox", sequencerAddr, l1Provider, sequencerPrKey);
+  pauseContract("L1StandardBridge", l1BridgeAddr, l1Provider, l1BridgePrKey);
+  pauseContract("L1Oracle", l1OracleAddr, l1Provider, l1OraclePrKey);
+  pauseContract("L1Portal", l1PortalAddr, l1Provider, l1PortalPrKey);
+
+  // Pause L2 Contracts
+  pauseContract("L2StandardBridge", l2BridgeAddr, l2Provider, l2BridgePrKey);
+  pauseContract("L2Portal", l2PortalAddr, l2Provider, l2PortalPrKey);
+  pauseContract("Faucet", faucetAddr, l2Provider, faucetPrKey);
+}
+
+async function unpauseContracts() {
+  // Unpause L1 Contracts
+  unpauseContract("Rollup", rollupAddr, l1Provider, rollupPrKey);
+  unpauseContract("SequencerInbox", sequencerAddr, l1Provider, sequencerPrKey);
+  unpauseContract("L1StandardBridge", l1BridgeAddr, l1Provider, l1BridgePrKey);
+  unpauseContract("L1Oracle", l1OracleAddr, l1Provider, l1OraclePrKey);
+  unpauseContract("L1Portal", l1PortalAddr, l1Provider, l1PortalPrKey);
+
+  // Unpause L2 Contracts
+  unpauseContract("L2StandardBridge", l2BridgeAddr, l2Provider, l2BridgePrKey);
+  unpauseContract("L2Portal", l2PortalAddr, l2Provider, l2PortalPrKey);
+  unpauseContract("Faucet", faucetAddr, l2Provider, faucetPrKey);
+}
+
+pauseContracts()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -143,7 +143,7 @@ contract Rollup is RollupBase {
       _unpause();
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /// @inheritdoc IRollup
     function currentRequiredStake() public view override returns (uint256) {

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -136,22 +136,19 @@ contract Rollup is RollupBase {
     }
 
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
     
     modifier hasConsensus() {
-      require(lastConfirmedAssertionID == lastCreatedAssertionID, "Rollup: no consensus");
-
-      _;
-
+        require(lastConfirmedAssertionID == lastCreatedAssertionID, "Rollup: no consensus");
+        _;
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused hasConsensus {}
-
 
     /// @inheritdoc IRollup
     function currentRequiredStake() public view override returns (uint256) {

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -135,6 +135,14 @@ contract Rollup is RollupBase {
         _disableInitializers();
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /// @inheritdoc IRollup

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -142,7 +142,7 @@ contract Rollup is RollupBase {
     function unpause() public onlyOwner {
         _unpause();
     }
-    
+
     modifier hasConsensus() {
         require(lastConfirmedAssertionID == lastCreatedAssertionID, "Rollup: no consensus");
         _;

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -25,7 +25,7 @@ pragma solidity ^0.8.0;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import "./challenge/IChallenge.sol";
 import "./challenge/SymChallenge.sol";
@@ -135,16 +135,16 @@ contract Rollup is RollupBase {
         _disableInitializers();
     }
 
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
     
     modifier hasConsensus() {
-      require(lastConfirmedAssertionID == lastCreatedAssertionID), "Rollup: no consensus");
+      require(lastConfirmedAssertionID == lastCreatedAssertionID, "Rollup: no consensus");
 
       _;
 

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -142,8 +142,16 @@ contract Rollup is RollupBase {
     function unpause() public override onlyOwner {
       _unpause();
     }
+    
+    modifier hasConsensus() {
+      require(lastConfirmedAssertionID == lastCreatedAssertionID), "Rollup: no consensus");
 
-    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
+      _;
+
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused hasConsensus {}
+
 
     /// @inheritdoc IRollup
     function currentRequiredStake() public view override returns (uint256) {

--- a/contracts/src/Rollup.sol
+++ b/contracts/src/Rollup.sol
@@ -221,7 +221,7 @@ contract Rollup is RollupBase {
     }
 
     /// @inheritdoc IRollup
-    function stake() external payable override whenNotPaused {
+    function stake() external payable override {
         if (isStaked(msg.sender)) {
             stakers[msg.sender].amountStaked += msg.value;
         } else {
@@ -320,7 +320,7 @@ contract Rollup is RollupBase {
     /// @inheritdoc IRollup
     function challengeAssertion(address[2] calldata players, uint256[2] calldata assertionIDs)
         external
-        override whenNotPaused
+        override
         returns (address)
     {
         uint256 defenderAssertionID = assertionIDs[0];

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -55,11 +55,11 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
     }
 
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -62,7 +62,7 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
       _unpause();
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /// @inheritdoc IDAProvider
     function getInboxSize() external view override returns (uint256) {

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -54,6 +54,14 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
         _disableInitializers();
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /// @inheritdoc IDAProvider

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -22,14 +22,16 @@
 
 pragma solidity ^0.8.0;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+
 import "./ISequencerInbox.sol";
 import "./libraries/DeserializationLib.sol";
 import "./libraries/Errors.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
-contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, OwnableUpgradeable, PauseableUpgradable {
     // Total number of transactions
     uint256 private inboxSize;
     // accumulators[i] is an accumulator of transactions in txBatch i.
@@ -43,6 +45,7 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
         }
         sequencerAddress = _sequencerAddress;
         __Ownable_init();
+        __Pausable_init();
         __UUPSUpgradeable_init();
     }
 
@@ -64,7 +67,7 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
         uint256[] calldata txLengths,
         uint256 firstL2BlockNumber,
         bytes calldata txBatch
-    ) external override {
+    ) external override whenNotPaused {
         if (msg.sender != sequencerAddress) {
             revert NotSequencer(msg.sender, sequencerAddress);
         }

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -25,13 +25,13 @@ pragma solidity ^0.8.0;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import "./ISequencerInbox.sol";
 import "./libraries/DeserializationLib.sol";
 import "./libraries/Errors.sol";
 
-contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, OwnableUpgradeable, PauseableUpgradable {
+contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     // Total number of transactions
     uint256 private inboxSize;
     // accumulators[i] is an accumulator of transactions in txBatch i.
@@ -54,11 +54,11 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
         _disableInitializers();
     }
 
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
 

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -48,11 +48,11 @@ contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     }
     
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
@@ -64,7 +64,11 @@ contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
      * @param _stateRoot L1 stateRoot.
      * @param _baseFee L1 baseFee.
      */
-    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee) external onlySequencer whenNotPaused {
+    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee) 
+        external 
+        onlySequencer 
+        whenNotPaused 
+    {
         blockNumber = _blockNumber;
         stateRoot = _stateRoot;
         baseFee = _baseFee;

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.4;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 
-contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /**
      * @notice Emitted when the L1 stateRoot is updated.
      */
@@ -43,6 +44,7 @@ contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     function initialize(address _sequencer) public initializer {
         sequencer = _sequencer;
         __Ownable_init();
+        __Pausable_init();
         __UUPSUpgradeable_init();
     }
 

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -46,7 +46,7 @@ contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
         __Pausable_init();
         __UUPSUpgradeable_init();
     }
-    
+
     function pause() public onlyOwner {
         _pause();
     }
@@ -64,10 +64,10 @@ contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
      * @param _stateRoot L1 stateRoot.
      * @param _baseFee L1 baseFee.
      */
-    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee) 
-        external 
-        onlySequencer 
-        whenNotPaused 
+    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee)
+        external
+        onlySequencer
+        whenNotPaused
     {
         blockNumber = _blockNumber;
         stateRoot = _stateRoot;

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -57,7 +57,7 @@ contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
      * @param _stateRoot L1 stateRoot.
      * @param _baseFee L1 baseFee.
      */
-    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee) external onlySequencer {
+    function setL1OracleValues(uint256 _blockNumber, bytes32 _stateRoot, uint256 _baseFee) external onlySequencer whenNotPaused {
         blockNumber = _blockNumber;
         stateRoot = _stateRoot;
         baseFee = _baseFee;

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
-contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /**
      * @notice Emitted when the L1 stateRoot is updated.
      */
@@ -46,6 +45,14 @@ contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         __Ownable_init();
         __Pausable_init();
         __UUPSUpgradeable_init();
+    }
+    
+    function pause() public onlyOwner {
+      _pause();
+    }
+
+    function unpause() public onlyOwner {
+      _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -48,7 +48,7 @@ contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         __UUPSUpgradeable_init();
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /**
      * @notice Updates the L1 block values.

--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
-contract L1Oracle is UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /**
      * @notice Emitted when the L1 stateRoot is updated.
      */

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -32,7 +32,14 @@ abstract contract L1PortalDeterministicStorage {
  *         and L2. Messages sent directly to the L1Portal have no form of replayability.
  *         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
  */
-contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L1Portal is 
+    L1PortalDeterministicStorage, 
+    IL1Portal, 
+    Initializable, 
+    UUPSUpgradeable, 
+    OwnableUpgradeable, 
+    PausableUpgradeable 
+{
     /**
      * @notice Value used to reset the l2Sender, this is more efficient than setting it to zero.
      */
@@ -101,11 +108,11 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
     }
 
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import {SafeCall} from "../libraries/SafeCall.sol";
 import {Types} from "../libraries/Types.sol";
@@ -100,11 +100,11 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
         l2PortalAddress = _l2PortalAddress;
     }
 
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
 

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -100,6 +100,14 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
         l2PortalAddress = _l2PortalAddress;
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /**

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -32,13 +32,13 @@ abstract contract L1PortalDeterministicStorage {
  *         and L2. Messages sent directly to the L1Portal have no form of replayability.
  *         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
  */
-contract L1Portal is 
-    L1PortalDeterministicStorage, 
-    IL1Portal, 
-    Initializable, 
-    UUPSUpgradeable, 
-    OwnableUpgradeable, 
-    PausableUpgradeable 
+contract L1Portal is
+    L1PortalDeterministicStorage,
+    IL1Portal,
+    Initializable,
+    UUPSUpgradeable,
+    OwnableUpgradeable,
+    PausableUpgradeable
 {
     /**
      * @notice Value used to reset the l2Sender, this is more efficient than setting it to zero.

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 
 import {SafeCall} from "../libraries/SafeCall.sol";
 import {Types} from "../libraries/Types.sol";
@@ -31,7 +32,7 @@ abstract contract L1PortalDeterministicStorage {
  *         and L2. Messages sent directly to the L1Portal have no form of replayability.
  *         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
  */
-contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /**
      * @notice Value used to reset the l2Sender, this is more efficient than setting it to zero.
      */
@@ -91,6 +92,7 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
         l2Sender = DEFAULT_L2_SENDER;
 
         __Ownable_init();
+        __Pausable_init();
         __UUPSUpgradeable_init();
     }
 
@@ -124,7 +126,7 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
         // bytes calldata encodedBlockHeader,
         bytes[] calldata withdrawalAccountProof,
         bytes[] calldata withdrawalProof
-    ) external override L2Deployed onlyProxy {
+    ) external override L2Deployed onlyProxy whenNotPaused {
         // Prevent nested withdrawals within withdrawals.
         require(l2Sender == DEFAULT_L2_SENDER, "L1Portal: can only trigger one withdrawal per transaction");
 
@@ -206,6 +208,7 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
         override
         L2Deployed
         onlyProxy
+        whenNotPaused
     {
         // Transform the from-address to its alias if the caller is a contract.
         address from = msg.sender;

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -108,7 +108,7 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
       _unpause();
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /**
      * @notice Accepts value so that users can send ETH directly to this contract and have the
@@ -116,7 +116,7 @@ contract L1Portal is L1PortalDeterministicStorage, IL1Portal, Initializable, UUP
      *         function for EOAs. Contracts should call the initiateDeposit() function directly
      *         otherwise any deposited funds will be lost due to address aliasing.
      */
-    receive() external payable {
+    receive() external payable whenNotPaused {
         initiateDeposit(msg.sender, RECEIVE_DEFAULT_GAS_LIMIT, bytes(""));
     }
 

--- a/contracts/src/bridge/L1StandardBridge.sol
+++ b/contracts/src/bridge/L1StandardBridge.sol
@@ -2,9 +2,6 @@
 pragma solidity ^0.8.11;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -13,7 +10,7 @@ import {L1Portal} from "./L1Portal.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L1StandardBridge is StandardBridge, Initializable {
     using SafeERC20 for IERC20;
 
     L1Portal public L1_PORTAL;
@@ -37,23 +34,13 @@ contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
     /// @notice Initializer;
     function initialize(address payable _l1Portal, address payable _otherBridge) public initializer {
         L1_PORTAL = L1Portal(_l1Portal);
-
-        __Ownable_init();
-        __Pausable_init();
-        __UUPSUpgradeable_init();
         __StandardBridge_init(_l1Portal, _otherBridge);
     }
 
-    function pause() public override onlyOwner {
-      _pause();
-    }
-
-    function unpause() public override onlyOwner {
-      _unpause();
-    }
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /// @inheritdoc StandardBridge
-    receive() external payable override {
+    receive() external payable override whenNotPaused {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, bytes(""));
     }
 
@@ -111,6 +98,4 @@ contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
             )
         );
     }
-
-    function _authorizeUpgrade(address) internal override onlyOwner {}
 }

--- a/contracts/src/bridge/L1StandardBridge.sol
+++ b/contracts/src/bridge/L1StandardBridge.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.11;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import {StandardBridge} from "./StandardBridge.sol";
 import {L1Portal} from "./L1Portal.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract L1StandardBridge is StandardBridge, Initializable {
+contract L1StandardBridge is StandardBridge {
     using SafeERC20 for IERC20;
 
     L1Portal public L1_PORTAL;

--- a/contracts/src/bridge/L1StandardBridge.sol
+++ b/contracts/src/bridge/L1StandardBridge.sol
@@ -44,6 +44,14 @@ contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
         __StandardBridge_init(_l1Portal, _otherBridge);
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     /// @inheritdoc StandardBridge
     receive() external payable override {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, bytes(""));

--- a/contracts/src/bridge/L1StandardBridge.sol
+++ b/contracts/src/bridge/L1StandardBridge.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.11;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {StandardBridge} from "./StandardBridge.sol";
 import {L1Portal} from "./L1Portal.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
     L1Portal public L1_PORTAL;
@@ -37,6 +39,7 @@ contract L1StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
         L1_PORTAL = L1Portal(_l1Portal);
 
         __Ownable_init();
+        __Pausable_init();
         __UUPSUpgradeable_init();
         __StandardBridge_init(_l1Portal, _otherBridge);
     }

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -24,7 +24,13 @@ abstract contract L2PortalDeterministicStorage {
     mapping(bytes32 => bool) public initiatedWithdrawals;
 }
 
-contract L2Portal is L2PortalDeterministicStorage, IL2Portal, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L2Portal is
+    L2PortalDeterministicStorage, 
+    IL2Portal, 
+    UUPSUpgradeable, 
+    OwnableUpgradeable, 
+    PausableUpgradeable 
+{
     /**
      * @notice Value used to reset the l1Sender, this is more efficient than setting it to zero.
      */
@@ -89,11 +95,11 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, UUPSUpgradeable, O
     }
 
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
@@ -119,7 +125,12 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, UUPSUpgradeable, O
      * @param _gasLimit Minimum gas limit for executing the message on L1.
      * @param _data     Data to forward to L1 target.
      */
-    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable onlyProxy whenNotPaused {
+    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) 
+        public 
+        payable 
+        onlyProxy 
+        whenNotPaused 
+    {
         bytes32 withdrawalHash = Hashing.hashCrossDomainMessage(
             Types.CrossDomainMessage({
                 version: 0,

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -25,11 +25,11 @@ abstract contract L2PortalDeterministicStorage {
 }
 
 contract L2Portal is
-    L2PortalDeterministicStorage, 
-    IL2Portal, 
-    UUPSUpgradeable, 
-    OwnableUpgradeable, 
-    PausableUpgradeable 
+    L2PortalDeterministicStorage,
+    IL2Portal,
+    UUPSUpgradeable,
+    OwnableUpgradeable,
+    PausableUpgradeable
 {
     /**
      * @notice Value used to reset the l1Sender, this is more efficient than setting it to zero.
@@ -125,11 +125,11 @@ contract L2Portal is
      * @param _gasLimit Minimum gas limit for executing the message on L1.
      * @param _data     Data to forward to L1 target.
      */
-    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) 
-        public 
-        payable 
-        onlyProxy 
-        whenNotPaused 
+    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data)
+        public
+        payable
+        onlyProxy
+        whenNotPaused
     {
         bytes32 withdrawalHash = Hashing.hashCrossDomainMessage(
             Types.CrossDomainMessage({

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 
 import {SafeCall} from "../libraries/SafeCall.sol";
 import {Types} from "../libraries/Types.sol";
@@ -111,7 +112,7 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUP
      * @param _gasLimit Minimum gas limit for executing the message on L1.
      * @param _data     Data to forward to L1 target.
      */
-    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable onlyProxy {
+    function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable onlyProxy whenNotPaused {
         bytes32 withdrawalHash = Hashing.hashCrossDomainMessage(
             Types.CrossDomainMessage({
                 version: 0,
@@ -137,7 +138,7 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUP
         Types.CrossDomainMessage memory depositTx,
         bytes[] calldata depositAccountProof,
         bytes[] calldata depositProof
-    ) external onlyProxy {
+    ) external onlyProxy whenNotPaused {
         // Prevent nested deposits within deposits.
         require(l1Sender == DEFAULT_L1_SENDER, "L2Portal: can only trigger one deposit per transaction");
 

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -89,6 +89,14 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUP
         __UUPSUpgradeable_init();
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     /**

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import {SafeCall} from "../libraries/SafeCall.sol";
 import {Types} from "../libraries/Types.sol";
@@ -25,7 +24,7 @@ abstract contract L2PortalDeterministicStorage {
     mapping(bytes32 => bool) public initiatedWithdrawals;
 }
 
-contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L2Portal is L2PortalDeterministicStorage, IL2Portal, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     /**
      * @notice Value used to reset the l1Sender, this is more efficient than setting it to zero.
      */
@@ -89,11 +88,11 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUP
         __UUPSUpgradeable_init();
     }
 
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
 

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -97,7 +97,7 @@ contract L2Portal is L2PortalDeterministicStorage, IL2Portal, Initializable, UUP
       _unpause();
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
 
     /**
      * @notice Allows users to withdraw ETH by sending directly to this contract.

--- a/contracts/src/bridge/L2StandardBridge.sol
+++ b/contracts/src/bridge/L2StandardBridge.sol
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -13,7 +9,7 @@ import {L2Portal} from "./L2Portal.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+contract L2StandardBridge is StandardBridge {
     using SafeERC20 for IERC20;
 
     L2Portal public L2_PORTAL;
@@ -38,18 +34,7 @@ contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
     function initialize(address payable _l2Portal, address payable _otherBridge) public initializer {
         L2_PORTAL = L2Portal(_l2Portal);
 
-        __Ownable_init();
-        __Pausable_init();
-        __UUPSUpgradeable_init();
         __StandardBridge_init(_l2Portal, _otherBridge);
-    }
-
-    function pause() public override onlyOwner {
-      _pause();
-    }
-
-    function unpause() public override onlyOwner {
-      _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}

--- a/contracts/src/bridge/L2StandardBridge.sol
+++ b/contracts/src/bridge/L2StandardBridge.sol
@@ -44,6 +44,14 @@ contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
         __StandardBridge_init(_l2Portal, _otherBridge);
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     /// @inheritdoc StandardBridge
     receive() external payable override {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, bytes(""));

--- a/contracts/src/bridge/L2StandardBridge.sol
+++ b/contracts/src/bridge/L2StandardBridge.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.4;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import {StandardBridge} from "./StandardBridge.sol";
 import {L2Portal} from "./L2Portal.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";
 import {AddressAliasHelper} from "../vendor/AddressAliasHelper.sol";
 
-contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
     L2Portal public L2_PORTAL;
@@ -37,6 +39,7 @@ contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
         L2_PORTAL = L2Portal(_l2Portal);
 
         __Ownable_init();
+        __Pausable_init();
         __UUPSUpgradeable_init();
         __StandardBridge_init(_l2Portal, _otherBridge);
     }

--- a/contracts/src/bridge/L2StandardBridge.sol
+++ b/contracts/src/bridge/L2StandardBridge.sol
@@ -52,8 +52,10 @@ contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
       _unpause();
     }
 
+    function _authorizeUpgrade(address) internal override onlyOwner whenPaused {}
+
     /// @inheritdoc StandardBridge
-    receive() external payable override {
+    receive() external payable override whenNotPaused {
         _initiateBridgeETH(msg.sender, msg.sender, msg.value, RECEIVE_DEFAULT_GAS_LIMIT, bytes(""));
     }
 
@@ -111,6 +113,4 @@ contract L2StandardBridge is StandardBridge, Initializable, UUPSUpgradeable, Own
             )
         );
     }
-
-    function _authorizeUpgrade(address) internal override onlyOwner {}
 }

--- a/contracts/src/bridge/StandardBridge.sol
+++ b/contracts/src/bridge/StandardBridge.sol
@@ -43,11 +43,11 @@ abstract contract StandardBridge is IStandardBridge, UUPSUpgradeable, OwnableUpg
     }
     
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     /// @notice Allows EOAs to bridge ETH by sending directly to the bridge.

--- a/contracts/src/bridge/StandardBridge.sol
+++ b/contracts/src/bridge/StandardBridge.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+
 import {IStandardBridge} from "./IStandardBridge.sol";
 import {SafeCall} from "../libraries/SafeCall.sol";
 import {IMintableERC20} from "./mintable/IMintableERC20.sol";

--- a/contracts/src/bridge/StandardBridge.sol
+++ b/contracts/src/bridge/StandardBridge.sol
@@ -41,7 +41,7 @@ abstract contract StandardBridge is IStandardBridge, UUPSUpgradeable, OwnableUpg
         __Pausable_init();
         __UUPSUpgradeable_init();
     }
-    
+
     function pause() public onlyOwner {
         _pause();
     }

--- a/contracts/src/bridge/StandardBridge.sol
+++ b/contracts/src/bridge/StandardBridge.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.4;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -42,11 +42,11 @@ abstract contract StandardBridge is IStandardBridge, UUPSUpgradeable, OwnableUpg
         __UUPSUpgradeable_init();
     }
     
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
 

--- a/contracts/src/pre-deploy/Faucet.sol
+++ b/contracts/src/pre-deploy/Faucet.sol
@@ -18,12 +18,16 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
 
-contract Faucet is UUPSUpgradeable, OwnableUpgradeable {
+contract Faucet is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     function initialize() public initializer {
+        __Pausable_init();
         __Ownable_init();
+        __UUPSUpgradeable_init();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
@@ -45,7 +49,7 @@ contract Faucet is UUPSUpgradeable, OwnableUpgradeable {
         payable(msg.sender).transfer(address(this).balance);
     }
 
-    function requestFunds(address payable requestor) public payable onlyOwner {
+    function requestFunds(address payable requestor) public payable onlyOwner whenNotPaused {
         require(block.timestamp > lockTime[requestor], "Lock time has not expired.");
         require(address(this).balance > amountAllowed, "Not enough funds in faucet.");
 

--- a/contracts/src/pre-deploy/Faucet.sol
+++ b/contracts/src/pre-deploy/Faucet.sol
@@ -30,6 +30,14 @@ contract Faucet is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableU
         __UUPSUpgradeable_init();
     }
 
+    function pause() public override onlyOwner {
+      _pause();
+    }
+
+    function unpause() public override onlyOwner {
+      _unpause();
+    }
+
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
     // amountAllowed is initialized in the genesis.json

--- a/contracts/src/pre-deploy/Faucet.sol
+++ b/contracts/src/pre-deploy/Faucet.sol
@@ -31,11 +31,11 @@ contract Faucet is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableU
     }
 
     function pause() public onlyOwner {
-      _pause();
+        _pause();
     }
 
     function unpause() public onlyOwner {
-      _unpause();
+        _unpause();
     }
 
     function _authorizeUpgrade(address) internal override onlyOwner {}

--- a/contracts/src/pre-deploy/Faucet.sol
+++ b/contracts/src/pre-deploy/Faucet.sol
@@ -21,7 +21,7 @@ pragma solidity ^0.8.0;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/PausableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 contract Faucet is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     function initialize() public initializer {
@@ -30,11 +30,11 @@ contract Faucet is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableU
         __UUPSUpgradeable_init();
     }
 
-    function pause() public override onlyOwner {
+    function pause() public onlyOwner {
       _pause();
     }
 
-    function unpause() public override onlyOwner {
+    function unpause() public onlyOwner {
       _unpause();
     }
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -250,7 +250,7 @@ contract RollupTest is RollupBaseSetup {
         (bool isAliceStaked,,,) = rollup.stakers(alice);
         assertTrue(!isAliceStaked);
     }
-    
+
     function testFuzz_stake_insufficentStake_reverts(
         uint256 confirmationPeriod,
         uint256 challengePeriod,
@@ -319,7 +319,7 @@ contract RollupTest is RollupBaseSetup {
         assertEq(assertionID, rollup.lastConfirmedAssertionID(), "assertionID not updated properly");
         assertEq(challengeAddress, address(0), "challengeAddress not updated properly");
     }
-    
+
     function test_stake_stakeWhenPaused_succeeds(
         uint256 confirmationPeriod,
         uint256 challengePeriod,
@@ -518,7 +518,7 @@ contract RollupTest is RollupBaseSetup {
 
         assertTrue(!isStakedAfterRemoveStake);
     }
-    
+
     function testFuzz_removeStakePaused_succeeds(
         uint256 confirmationPeriod,
         uint256 challengePeriod,
@@ -539,11 +539,11 @@ contract RollupTest is RollupBaseSetup {
         _stake(alice, aliceAmountToStake);
 
         uint256 aliceBalanceBeforeRemoveStake = alice.balance;
-       
+
         // as owner pause
         vm.prank(deployer);
         rollup.pause();
-        
+
         // as alice, attempt to remove stake
         vm.prank(alice);
         rollup.removeStake(address(alice));
@@ -673,7 +673,7 @@ contract RollupTest is RollupBaseSetup {
 
         assertEq((aliceBalanceFinal - aliceBalanceInitial), amountToWithdraw, "Desired amount could not be withdrawn.");
     }
-    
+
     function testFuzz_unstakePaused_succeeds(
         uint256 confirmationPeriod,
         uint256 challengePeriod,
@@ -907,7 +907,7 @@ contract RollupTest is RollupBaseSetup {
         assertEq(bobAmountToStake, bobAmountStakedFinal);
         assertEq(bobAssertionIdFinal, 1);
     }
-    
+
     function testFuzz_advanceStake_paused_reverts(uint256 confirmationPeriod, uint256 challengePeriod) external {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
@@ -945,7 +945,7 @@ contract RollupTest is RollupBaseSetup {
         // run paused then unpause and proceed with test.
         vm.prank(deployer);
         rollup.pause();
-       
+
         // try as alice
         vm.expectRevert("Pausable: paused");
         vm.prank(alice);
@@ -954,7 +954,7 @@ contract RollupTest is RollupBaseSetup {
         // unpause and continue setup
         vm.prank(deployer);
         rollup.unpause();
-        
+
         // try again now that pause is over
         vm.prank(alice);
         rollup.createAssertion(mockVmHash, mockInboxSize);
@@ -1116,7 +1116,7 @@ contract RollupTest is RollupBaseSetup {
         vm.expectRevert(IRollup.AssertionAlreadyResolved.selector);
         rollup.challengeAssertion(players, assertionIDs);
     }
-    
+
     /////////////////////////
     // Auxillary Functions
     /////////////////////////

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -539,10 +539,12 @@ contract RollupTest is RollupBaseSetup {
         _stake(alice, aliceAmountToStake);
 
         uint256 aliceBalanceBeforeRemoveStake = alice.balance;
-        
+       
+        // as owner pause
         vm.prank(deployer);
         rollup.pause();
         
+        // as alice, attempt to remove stake
         vm.prank(alice);
         rollup.removeStake(address(alice));
 
@@ -697,9 +699,11 @@ contract RollupTest is RollupBaseSetup {
 
         amountToWithdraw = _generateRandomUintInRange(1, (aliceAmountToStake - minimumAmount), amountToWithdraw);
 
+        // as the owner, pause
         vm.prank(deployer);
         rollup.pause();
 
+        // as alice, attempt to unstake
         vm.prank(alice);
         rollup.unstake(amountToWithdraw);
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -904,7 +904,7 @@ contract RollupTest is RollupBaseSetup {
         assertEq(bobAssertionIdFinal, 1);
     }
     
-    function testFuzz_advanceStakePaused_reverts(uint256 confirmationPeriod, uint256 challengePeriod) external {
+    function testFuzz_advanceStake_paused_reverts(uint256 confirmationPeriod, uint256 challengePeriod) external {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -357,7 +357,6 @@ contract RollupTest is RollupBaseSetup {
         assertEq(amountStaked, aliceBalance, "amountStaked not updated properly");
         assertEq(assertionID, rollup.lastConfirmedAssertionID(), "assertionID not updated properly");
         assertEq(challengeAddress, address(0), "challengeAddress not updated properly");
-
     }
 
     function testFuzz_stake_increaseStake_succeeds(

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -241,7 +241,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         vm.prank(sequencerAddress);
         seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
     }
-    
+
     function test_appendTxBatch_paused_reverts(uint256 numTxnsPerBlock, uint256 txnBlocks) public {
         // We will operate at a limit of transactionsPerBlock = 30 and number of transactionBlocks = 10.
         numTxnsPerBlock = bound(numTxnsPerBlock, 1, 30);

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -240,6 +240,52 @@ contract SequencerInboxTest is SequencerBaseSetup {
         vm.prank(sequencerAddress);
         seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
     }
+    
+    function test_appendTxBatch_paused_reverts(uint256 numTxnsPerBlock, uint256 txnBlocks) public {
+        // We will operate at a limit of transactionsPerBlock = 30 and number of transactionBlocks = 10.
+        numTxnsPerBlock = bound(numTxnsPerBlock, 1, 30);
+        txnBlocks = bound(txnBlocks, 1, 10);
+
+        sqIn.pause();
+
+        uint256 inboxSizeInitial = seqIn.getInboxSize();
+
+        // Each context corresponds to a single "L2 block"
+        uint256 numTxns = numTxnsPerBlock * txnBlocks;
+        // Each `context` is represented with uint256 2-tuple: (numTxs, l2Timestamp)
+        uint256 numContextsArrEntries = 2 * txnBlocks;
+
+        // Making sure that the block.timestamp is a reasonable value (> txnBlocks)
+        vm.warp(block.timestamp + (4 * txnBlocks));
+        uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
+        // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
+
+        uint256 firstL2BlockNumber = block.timestamp / 20;
+
+        // Let's create an array of contexts
+        uint256[] memory contexts = new uint256[](numContextsArrEntries);
+        for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
+            // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
+            contexts[i] = numTxnsPerBlock;
+
+            // Formula used for blockTimestamp: (current block.timestamp) / 5x
+            contexts[i + 1] = txnBlockTimestamp;
+
+            // The only requirement for timestamps for the transaction blocks is that, these timestamps are monotonically increasing.
+            // So, let's increase the value of txnBlock's timestamp monotonically, in a way that is does not exceed current block.timestamp
+            ++txnBlockTimestamp;
+        }
+
+        // txLengths is defined as: Array of lengths of each encoded tx in txBatch
+        // txBatch is defined as: Batch of RLP-encoded transactions
+        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTxns);
+
+        // Pranking as the sequencer and calling appendTxBatch
+        vm.prank(sequencerAddress);
+        vm.expectRevert(ISequencerInbox.EnforcedPause.selector);
+        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
+
+    }
 
     /////////////////////////////////////////////////////////////////////////////////////////
     // TENTATIVE CODE CHANGE. TEST SUBJECT TO CHANGE BASED ON CHANGE IN CODE

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -23,6 +23,7 @@ import "forge-std/Test.sol";
 import "../src/ISequencerInbox.sol";
 import "../src/libraries/Errors.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import {SequencerInbox} from "../src/SequencerInbox.sol";
 import {Utils} from "./utils/Utils.sol";
 import {RLPEncodedTransactionsUtil} from "./utils/RLPEncodedTransactions.sol";
@@ -246,7 +247,8 @@ contract SequencerInboxTest is SequencerBaseSetup {
         numTxnsPerBlock = bound(numTxnsPerBlock, 1, 30);
         txnBlocks = bound(txnBlocks, 1, 10);
 
-        sqIn.pause();
+        vm.prank(sequencerOwner);
+        seqIn.pause();
 
         uint256 inboxSizeInitial = seqIn.getInboxSize();
 
@@ -282,7 +284,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        vm.expectRevert(ISequencerInbox.EnforcedPause.selector);
+        vm.expectRevert("Pausable: paused");
         seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
 
     }

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -286,7 +286,6 @@ contract SequencerInboxTest is SequencerBaseSetup {
         vm.prank(sequencerAddress);
         vm.expectRevert("Pausable: paused");
         seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatch);
-
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -24,19 +28,19 @@ importers:
         version: 10.2.4
       hardhat:
         specifier: ^2.14.0
-        version: 2.14.0(ts-node@10.9.1)(typescript@4.9.3)
+        version: 2.14.0(ts-node@10.9.1)(typescript@4.9.5)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.13.0)(typescript@4.9.3)
+        version: 10.9.1(@types/node@18.14.2)(typescript@4.9.5)
 
   contracts:
     dependencies:
       '@openzeppelin/contracts':
-        specifier: ^4.8.3
-        version: 4.8.3
+        specifier: ^4.9.3
+        version: 4.9.3
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^4.8.3
-        version: 4.8.3
+        specifier: ^4.9.3
+        version: 4.9.3
       '@openzeppelin/hardhat-upgrades':
         specifier: ^1.22.1
         version: 1.22.1(@nomiclabs/hardhat-etherscan@3.1.0)(ethers@5.7.2)(hardhat-deploy-ethers@0.3.0-beta.13)(hardhat@2.12.7)
@@ -126,55 +130,6 @@ importers:
         specifier: ^4.9.3
         version: 4.9.3
 
-  relayer:
-    dependencies:
-      '@ethersproject/experimental':
-        specifier: ^5.7.0
-        version: 5.7.0
-      '@types/node':
-        specifier: ^18.14.2
-        version: 18.14.2
-      commander:
-        specifier: ^10.0.0
-        version: 10.0.0
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
-      ethers:
-        specifier: ^5.7.2
-        version: 5.7.2
-      express:
-        specifier: ^4.18.2
-        version: 4.18.2
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.14.2)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
-      typescript-collections:
-        specifier: ^1.3.3
-        version: 1.3.3
-    devDependencies:
-      '@ethersproject/providers':
-        specifier: ^5.7.2
-        version: 5.7.2
-      '@types/express':
-        specifier: ^4.17.17
-        version: 4.17.17
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.54.0
-        version: 5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.35.0)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.54.0
-        version: 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      eslint:
-        specifier: ^8.35.0
-        version: 8.35.0
-      prettier:
-        specifier: ^2.8.4
-        version: 2.8.4
-
 packages:
 
   /@babel/code-frame@7.18.6:
@@ -256,7 +211,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       espree: 9.5.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -266,28 +221,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@eslint/eslintrc@2.1.0:
-    resolution: {integrity: sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.3.1)
-      espree: 9.6.0
-      globals: 13.20.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@eslint/js@8.35.0:
-    resolution: {integrity: sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@ethereum-waffle/chai@3.4.4:
@@ -463,17 +396,6 @@ packages:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/transactions': 5.7.0
-
-  /@ethersproject/experimental@5.7.0:
-    resolution: {integrity: sha512-DWvhuw7Dg8JPyhMbh/CNYOwsTLjXRx/HGkacIL5rBocG8jJC0kmixwoK/J3YblO4vtcyBLMa+sV74RJZK2iyHg==}
-    dependencies:
-      '@ethersproject/web': 5.7.1
-      ethers: 5.7.2
-      scrypt-js: 3.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
 
   /@ethersproject/hash@5.7.0:
     resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
@@ -686,7 +608,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -818,7 +740,7 @@ packages:
       '@nomicfoundation/ethereumjs-trie': 5.0.5
       '@nomicfoundation/ethereumjs-util': 8.0.6
       abstract-level: 1.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       level: 8.0.0
       lru-cache: 5.1.1
@@ -838,7 +760,7 @@ packages:
       '@nomicfoundation/ethereumjs-tx': 5.0.1
       '@nomicfoundation/ethereumjs-util': 9.0.1
       abstract-level: 1.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       level: 8.0.0
       lru-cache: 5.1.1
@@ -896,7 +818,7 @@ packages:
       '@nomicfoundation/ethereumjs-util': 8.0.6
       '@types/async-eventemitter': 0.2.1
       async-eventemitter: 0.2.4
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       mcl-wasm: 0.7.9
       rustbn.js: 0.2.0
@@ -911,7 +833,7 @@ packages:
       '@nomicfoundation/ethereumjs-common': 4.0.1
       '@nomicfoundation/ethereumjs-tx': 5.0.1
       '@nomicfoundation/ethereumjs-util': 9.0.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       mcl-wasm: 0.7.9
       rustbn.js: 0.2.0
@@ -939,7 +861,7 @@ packages:
       '@nomicfoundation/ethereumjs-rlp': 4.0.3
       '@nomicfoundation/ethereumjs-trie': 5.0.5
       '@nomicfoundation/ethereumjs-util': 8.0.6
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       functional-red-black-tree: 1.0.1
     transitivePeerDependencies:
@@ -950,7 +872,7 @@ packages:
     dependencies:
       '@nomicfoundation/ethereumjs-common': 4.0.1
       '@nomicfoundation/ethereumjs-rlp': 5.0.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       ethers: 5.7.2
       js-sdsl: 4.4.0
@@ -1035,7 +957,7 @@ packages:
       '@nomicfoundation/ethereumjs-util': 8.0.6
       '@types/async-eventemitter': 0.2.1
       async-eventemitter: 0.2.4
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       functional-red-black-tree: 1.0.1
       mcl-wasm: 0.7.9
@@ -1056,7 +978,7 @@ packages:
       '@nomicfoundation/ethereumjs-trie': 6.0.1
       '@nomicfoundation/ethereumjs-tx': 5.0.1
       '@nomicfoundation/ethereumjs-util': 9.0.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereum-cryptography: 0.1.3
       mcl-wasm: 0.7.9
       rustbn.js: 0.2.0
@@ -1170,7 +1092,7 @@ packages:
       '@ethersproject/address': 5.7.0
       cbor: 5.2.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       fs-extra: 7.0.1
       hardhat: 2.12.7(ts-node@10.9.1)(typescript@4.9.3)
       lodash: 4.17.21
@@ -1196,12 +1118,12 @@ packages:
       hardhat: 2.12.7(ts-node@10.9.1)(typescript@4.9.3)
     dev: true
 
-  /@openzeppelin/contracts-upgradeable@4.8.3:
-    resolution: {integrity: sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==}
+  /@openzeppelin/contracts-upgradeable@4.9.3:
+    resolution: {integrity: sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==}
     dev: false
 
-  /@openzeppelin/contracts@4.8.3:
-    resolution: {integrity: sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==}
+  /@openzeppelin/contracts@4.9.3:
+    resolution: {integrity: sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==}
     dev: false
 
   /@openzeppelin/hardhat-upgrades@1.22.1(@nomiclabs/hardhat-etherscan@3.1.0)(ethers@5.7.2)(hardhat-deploy-ethers@0.3.0-beta.13)(hardhat@2.12.7):
@@ -1221,7 +1143,7 @@ packages:
       '@nomiclabs/hardhat-etherscan': 3.1.0(hardhat@2.12.7)
       '@openzeppelin/upgrades-core': 1.24.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethers: 5.7.2
       hardhat: 2.12.7(ts-node@10.9.1)(typescript@4.9.3)
       proper-lockfile: 4.1.2
@@ -1235,7 +1157,7 @@ packages:
       cbor: 8.1.0
       chalk: 4.1.2
       compare-versions: 5.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       ethereumjs-util: 7.1.5
       proper-lockfile: 4.1.2
       solidity-ast: 0.4.46
@@ -1678,13 +1600,6 @@ packages:
     dependencies:
       '@types/node': 18.14.2
 
-  /@types/body-parser@1.19.2:
-    resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
-    dependencies:
-      '@types/connect': 3.4.35
-      '@types/node': 18.14.2
-    dev: true
-
   /@types/cacheable-request@6.0.3:
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
     dependencies:
@@ -1699,38 +1614,10 @@ packages:
     resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
     dev: true
 
-  /@types/connect@3.4.35:
-    resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
-    dependencies:
-      '@types/node': 18.14.2
-    dev: true
-
-  /@types/express-serve-static-core@4.17.35:
-    resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
-    dependencies:
-      '@types/node': 18.14.2
-      '@types/qs': 6.9.7
-      '@types/range-parser': 1.2.4
-      '@types/send': 0.17.1
-    dev: true
-
-  /@types/express@4.17.17:
-    resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
-    dependencies:
-      '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.35
-      '@types/qs': 6.9.7
-      '@types/serve-static': 1.15.2
-    dev: true
-
   /@types/http-cache-semantics@4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
     dev: true
     optional: true
-
-  /@types/http-errors@2.0.1:
-    resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
-    dev: true
 
   /@types/inquirer@9.0.3:
     resolution: {integrity: sha512-CzNkWqQftcmk2jaCWdBTf9Sm7xSw4rkI1zpU/Udw3HX5//adEZUIm9STtoRP1qgWj0CWQtJ9UTvqmO2NNjhMJw==}
@@ -1752,14 +1639,6 @@ packages:
 
   /@types/lru-cache@5.1.1:
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
-
-  /@types/mime@1.3.2:
-    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: true
-
-  /@types/mime@3.0.1:
-    resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
-    dev: true
 
   /@types/mkdirp@0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
@@ -1827,21 +1706,6 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
-  /@types/send@0.17.1:
-    resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
-    dependencies:
-      '@types/mime': 1.3.2
-      '@types/node': 18.14.2
-    dev: true
-
-  /@types/serve-static@1.15.2:
-    resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
-    dependencies:
-      '@types/http-errors': 2.0.1
-      '@types/mime': 3.0.1
-      '@types/node': 18.14.2
-    dev: true
-
   /@types/sinon-chai@3.2.9:
     resolution: {integrity: sha512-/19t63pFYU0ikrdbXKBWj9PCdnKyTd0Qkz0X91Ta081cYsq90OxYdcWwK/dwEoDa6dtXgj2HJfmzgq+QZTHdmQ==}
     dependencies:
@@ -1891,7 +1755,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.52.0
       '@typescript-eslint/type-utils': 5.52.0(eslint@8.34.0)(typescript@4.9.3)
       '@typescript-eslint/utils': 5.52.0(eslint@8.34.0)(typescript@4.9.3)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       eslint: 8.34.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
@@ -1900,34 +1764,6 @@ packages:
       semver: 7.3.8
       tsutils: 3.21.0(typescript@4.9.3)
       typescript: 4.9.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/eslint-plugin@5.54.0(@typescript-eslint/parser@5.54.0)(eslint@8.35.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/type-utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.3.1)
-      eslint: 8.35.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      regexpp: 3.2.0
-      semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1945,29 +1781,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.52.0
       '@typescript-eslint/types': 5.52.0
       '@typescript-eslint/typescript-estree': 5.52.0(typescript@4.9.3)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       eslint: 8.34.0
       typescript: 4.9.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@5.54.0(eslint@8.35.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.3.1)
-      eslint: 8.35.0
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1978,14 +1794,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.52.0
       '@typescript-eslint/visitor-keys': 5.52.0
-    dev: true
-
-  /@typescript-eslint/scope-manager@5.54.0:
-    resolution: {integrity: sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/visitor-keys': 5.54.0
     dev: true
 
   /@typescript-eslint/type-utils@5.52.0(eslint@8.34.0)(typescript@4.9.3):
@@ -2000,7 +1808,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.52.0(typescript@4.9.3)
       '@typescript-eslint/utils': 5.52.0(eslint@8.34.0)(typescript@4.9.3)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       eslint: 8.34.0
       tsutils: 3.21.0(typescript@4.9.3)
       typescript: 4.9.3
@@ -2008,33 +1816,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.54.0(eslint@8.35.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.54.0(eslint@8.35.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@9.3.1)
-      eslint: 8.35.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/types@5.52.0:
     resolution: {integrity: sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /@typescript-eslint/types@5.54.0:
-    resolution: {integrity: sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -2049,33 +1832,12 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.52.0
       '@typescript-eslint/visitor-keys': 5.52.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
       tsutils: 3.21.0(typescript@4.9.3)
       typescript: 4.9.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/typescript-estree@5.54.0(typescript@4.9.5):
-    resolution: {integrity: sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/visitor-keys': 5.54.0
-      debug: 4.3.4(supports-color@9.3.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2100,40 +1862,12 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.54.0(eslint@8.35.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.54.0
-      '@typescript-eslint/types': 5.54.0
-      '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
-      eslint: 8.35.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.35.0)
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/visitor-keys@5.52.0:
     resolution: {integrity: sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.52.0
       eslint-visitor-keys: 3.4.0
-    dev: true
-
-  /@typescript-eslint/visitor-keys@5.54.0:
-    resolution: {integrity: sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.54.0
-      eslint-visitor-keys: 3.4.1
     dev: true
 
   /@yarnpkg/lockfile@1.1.0:
@@ -2212,6 +1946,8 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+    dev: true
+    optional: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2219,14 +1955,6 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.8.2
-    dev: true
-
-  /acorn-jsx@5.3.2(acorn@8.9.0):
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.9.0
     dev: true
 
   /acorn-walk@8.2.0:
@@ -2237,12 +1965,6 @@ packages:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  /acorn@8.9.0:
-    resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
 
   /adm-zip@0.4.16:
     resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
@@ -2260,7 +1982,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -2399,6 +2121,8 @@ packages:
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    dev: true
+    optional: true
 
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -3143,6 +2867,8 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+    optional: true
 
   /body-parser@1.20.2:
     resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
@@ -3761,6 +3487,8 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
+    dev: true
+    optional: true
 
   /content-hash@2.5.2:
     resolution: {integrity: sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==}
@@ -3774,6 +3502,8 @@ packages:
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -3781,6 +3511,8 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: true
+    optional: true
 
   /cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
@@ -3789,6 +3521,8 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -3931,6 +3665,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
+    dev: true
 
   /debug@3.2.6:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
@@ -3955,6 +3690,17 @@ packages:
       ms: 2.1.3
     dev: true
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -3978,6 +3724,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.3.1
+    dev: false
 
   /decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
@@ -4132,6 +3879,8 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: true
+    optional: true
 
   /detect-indent@4.0.0:
     resolution: {integrity: sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==}
@@ -4180,11 +3929,6 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /dotenv@16.0.3:
-    resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
-    engines: {node: '>=12'}
-    dev: false
-
   /dotignore@0.1.2:
     resolution: {integrity: sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==}
     hasBin: true
@@ -4210,6 +3954,8 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: true
+    optional: true
 
   /electron-to-chromium@1.4.342:
     resolution: {integrity: sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==}
@@ -4247,6 +3993,8 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
+    dev: true
+    optional: true
 
   /encoding-down@5.0.4:
     resolution: {integrity: sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==}
@@ -4387,6 +4135,8 @@ packages:
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: true
+    optional: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -4422,16 +4172,6 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@8.35.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.35.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
   /eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
@@ -4439,11 +4179,6 @@ packages:
 
   /eslint-visitor-keys@3.4.0:
     resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -4459,60 +4194,11 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
       eslint-utils: 3.0.0(eslint@8.34.0)
-      eslint-visitor-keys: 3.4.0
-      espree: 9.5.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.20.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-sdsl: 4.4.0
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      regexpp: 3.2.0
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /eslint@8.35.0:
-    resolution: {integrity: sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint/eslintrc': 2.1.0
-      '@eslint/js': 8.35.0
-      '@humanwhocodes/config-array': 0.11.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.3.1)
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.1.1
-      eslint-utils: 3.0.0(eslint@8.35.0)
       eslint-visitor-keys: 3.4.0
       espree: 9.5.1
       esquery: 1.5.0
@@ -4553,15 +4239,6 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /espree@9.6.0:
-    resolution: {integrity: sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      acorn: 8.9.0
-      acorn-jsx: 5.3.2(acorn@8.9.0)
-      eslint-visitor-keys: 3.4.1
-    dev: true
-
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -4594,6 +4271,8 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /eth-block-tracker@3.0.1:
     resolution: {integrity: sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==}
@@ -5124,6 +4803,8 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+    optional: true
 
   /ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -5267,6 +4948,8 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+    optional: true
 
   /find-replace@1.0.3:
     resolution: {integrity: sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==}
@@ -5354,7 +5037,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -5409,6 +5092,8 @@ packages:
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /fp-ts@1.19.3:
     resolution: {integrity: sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==}
@@ -5423,6 +5108,8 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /fs-extra@0.30.0:
     resolution: {integrity: sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==}
@@ -5805,7 +5492,7 @@ packages:
       axios: 0.21.4(debug@4.3.4)
       chalk: 4.1.2
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       enquirer: 2.3.6
       ethers: 5.7.2
       form-data: 4.0.0
@@ -5856,7 +5543,7 @@ packages:
       chalk: 2.4.2
       chokidar: 3.5.3
       ci-info: 2.0.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       enquirer: 2.3.6
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -5890,7 +5577,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /hardhat@2.14.0(ts-node@10.9.1)(typescript@4.9.3):
+  /hardhat@2.14.0(ts-node@10.9.1)(typescript@4.9.5):
     resolution: {integrity: sha512-73jsInY4zZahMSVFurSK+5TNCJTXMv+vemvGia0Ac34Mm19fYp6vEPVGF3sucbumszsYxiTT2TbS8Ii2dsDSoQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -5926,7 +5613,7 @@ packages:
       chalk: 2.4.2
       chokidar: 3.5.3
       ci-info: 2.0.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       enquirer: 2.3.6
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -5949,9 +5636,9 @@ packages:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.1(@types/node@18.13.0)(typescript@4.9.3)
+      ts-node: 10.9.1(@types/node@18.14.2)(typescript@4.9.5)
       tsort: 0.0.1
-      typescript: 4.9.3
+      typescript: 4.9.5
       undici: 5.21.0
       uuid: 8.3.2
       ws: 7.5.9
@@ -6123,7 +5810,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -6265,6 +5952,8 @@ packages:
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+    dev: true
+    optional: true
 
   /is-accessor-descriptor@0.1.6:
     resolution: {integrity: sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==}
@@ -7195,6 +6884,8 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /mem@8.1.1:
     resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
@@ -7241,6 +6932,8 @@ packages:
 
   /merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    dev: true
+    optional: true
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -7278,6 +6971,8 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /micromatch@3.1.10:
     resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
@@ -7318,17 +7013,21 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: true
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+    optional: true
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -7490,6 +7189,7 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -7607,6 +7307,8 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
@@ -7790,6 +7492,8 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
+    dev: true
+    optional: true
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -7958,6 +7662,8 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+    optional: true
 
   /pascalcase@0.1.1:
     resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==}
@@ -8065,6 +7771,8 @@ packages:
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: true
+    optional: true
 
   /path-type@1.1.0:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
@@ -8193,6 +7901,8 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+    dev: true
+    optional: true
 
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -8285,6 +7995,8 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: true
+    optional: true
 
   /qs@6.11.1:
     resolution: {integrity: sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==}
@@ -8338,6 +8050,8 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+    dev: true
+    optional: true
 
   /raw-body@2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -8347,6 +8061,8 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+    dev: true
+    optional: true
 
   /raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -8781,6 +8497,8 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+    optional: true
 
   /serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
@@ -8797,6 +8515,8 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+    optional: true
 
   /servify@0.1.12:
     resolution: {integrity: sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==}
@@ -9308,6 +9028,7 @@ packages:
   /supports-color@9.3.1:
     resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
+    dev: false
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -9635,16 +9356,6 @@ packages:
       typescript: 4.9.3
     dev: true
 
-  /tsutils@3.21.0(typescript@4.9.5):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.9.5
-    dev: true
-
   /tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
@@ -9692,6 +9403,8 @@ packages:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+    dev: true
+    optional: true
 
   /type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
@@ -9706,7 +9419,7 @@ packages:
     hasBin: true
     dependencies:
       command-line-args: 4.0.7
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       fs-extra: 7.0.1
       js-sha3: 0.8.0
       lodash: 4.17.21
@@ -9724,7 +9437,7 @@ packages:
       typescript: '>=4.3.0'
     dependencies:
       '@types/prettier': 2.7.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -9758,10 +9471,6 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript-collections@1.3.3:
-    resolution: {integrity: sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ==}
-    dev: false
-
   /typescript@4.9.3:
     resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
@@ -9771,6 +9480,7 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: false
 
   /typewise-core@1.2.0:
     resolution: {integrity: sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==}
@@ -9924,6 +9634,8 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+    dev: true
+    optional: true
 
   /uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
@@ -9965,6 +9677,8 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+    dev: true
+    optional: true
 
   /verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Implement `PausableUpgradeable` from OpenZeppelin for the SequencerInbox, Rollup and Bridge contracts
- Use modifier `whenPaused` to decorate `_authorizeUpgrade` so that upgrade can only be authorized when paused.
- Use modifier `whenNotPaused` to decorate particular functions that would progress the state of the contracts such that new consensus must be arrived at. Namely, prevent bridge transfers (requires confirmation), prevent new assertions from being created (requiring confirmation), preventing new stakers from staking and prevent new transaction batches from being appended (as they need to be asserted and confirmed),
- Testing some basic functionalities are correctly disabled when the contracts are paused.
- Adds a method `hasConsensus` for checking if `Rollup.sol` has reached a consensus state (all challenges have been resolved) which gets run for `_authorizeUpgrade()`.
- scripts which pause and check for consensus and which unpause the contracts for use when we need to upgrade

Notes:

- This isn't thoroughly unit tested, but I capture most of the important aspects (staking/unstaking/removingStake/progressing assertions/appendingTxs). In particular, we are missing tests for anything that doesn't use the `whenPaused`/`whenNotPaused`.
- Not decided on whether stakers can join or leave during pause (code currently allows for both).
- This does not test bridge code and overall there is a lack of testing bridge code, possibly because we don't have a good way of testing it? Something left to future work.
- Uncertain if upgrades should be blocked on consensus.
