### PR TITLE
portal retryability

### DIFF
--- a/contracts/scripts/bridge/standard_bridge_retry.ts
+++ b/contracts/scripts/bridge/standard_bridge_retry.ts
@@ -1,0 +1,92 @@
+// NOTE: this test will fail without portal level retryability
+import { ethers } from "hardhat";
+import { getSignersAndContracts, getDepositProof } from "./utils";
+
+async function main() {
+  const {
+    l1Provider,
+    l2Provider,
+    l2Bridger,
+    l1Portal,
+    l2Portal,
+    l1StandardBridge,
+    l1Oracle,
+  } = await getSignersAndContracts();
+
+  const balanceStart = await l2Bridger.getBalance();
+  const portalBalance = await l2Provider.getBalance(l2Portal.address);
+  const bridgeValue = portalBalance.add(10);
+
+  console.log({ balanceStart: ethers.utils.formatEther(balanceStart) });
+  console.log({ bridgeValue: ethers.utils.formatEther(bridgeValue) });
+
+  const bridgeTx = await l1StandardBridge.bridgeETH(200_000, [], {
+    value: bridgeValue,
+  });
+  const txWithLogs = await bridgeTx.wait();
+
+  const initEvent = await l1Portal.interface.parseLog(txWithLogs.logs[1]);
+  const crossDomainMessage = {
+    version: 0,
+    nonce: initEvent.args.nonce,
+    sender: initEvent.args.sender,
+    target: initEvent.args.target,
+    value: initEvent.args.value,
+    gasLimit: initEvent.args.gasLimit,
+    data: initEvent.args.data,
+  };
+
+  const blockNumber = await l1Provider.getBlockNumber();
+  const rawBlock = await l1Provider.send("eth_getBlockByNumber", [
+    ethers.utils.hexValue(blockNumber),
+    false, // We only want the block header
+  ]);
+  const stateRoot = l1Provider.formatter.hash(rawBlock.stateRoot);
+  await l1Oracle.setL1OracleValues(blockNumber, stateRoot, 0);
+
+  const { accountProof, storageProof } = await getDepositProof(
+    l1Portal.address,
+    blockNumber,
+    initEvent.args.depositHash
+  );
+
+  const finalizeTx = await l2Portal.finalizeDepositTransaction(
+    crossDomainMessage,
+    accountProof,
+    storageProof
+  );
+  await finalizeTx.wait();
+
+  const balanceEnd = await l2Bridger.getBalance();
+  console.log({ balanceEnd: ethers.utils.formatEther(balanceEnd) });
+  if (balanceEnd.sub(balanceStart).eq(bridgeValue)) {
+    throw "unexpected end balance";
+  }
+
+  const donateTx = await l2Portal.donateETH({
+    value: ethers.utils.parseUnits("1"),
+  });
+  await donateTx.wait();
+
+  const retryTx = await l2Portal.finalizeDepositTransaction(
+    crossDomainMessage,
+    accountProof,
+    storageProof
+  );
+  await retryTx.wait();
+
+  const balanceFinal = await l2Bridger.getBalance();
+  console.log({ balanceFinal: ethers.utils.formatEther(balanceFinal) });
+  if (!balanceFinal.sub(balanceStart).eq(bridgeValue)) {
+    throw "unexpected end balance";
+  }
+
+  console.log("bridging ETH was successful");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -202,11 +202,11 @@ contract L1Portal is
         // call to run out of gas via a returndata bomb.
         bool success = SafeCall.call(withdrawalTx.target, withdrawalTx.gasLimit, withdrawalTx.value, withdrawalTx.data);
 
+        require(success, "L2Portal: call to target contract reverted");
+
         // Reset the l2Sender back to the default value.
         l2Sender = DEFAULT_L2_SENDER;
 
-        // All withdrawals are immediately finalized. Replayability can
-        // be achieved through contracts built on top of this contract
         emit WithdrawalFinalized(withdrawalHash, success);
     }
 

--- a/contracts/src/bridge/L2Portal.sol
+++ b/contracts/src/bridge/L2Portal.sol
@@ -201,11 +201,11 @@ contract L2Portal is
         // call to run out of gas via a returndata bomb.
         bool success = SafeCall.call(depositTx.target, depositTx.gasLimit, depositTx.value, depositTx.data);
 
+        require(success, "L2Portal: call to target contract reverted");
+
         // Reset the l2Sender back to the default value.
         l1Sender = DEFAULT_L1_SENDER;
 
-        // All deposits are immediately finalized. Replayability can
-        // be achieved through contracts built on top of this contract
         emit DepositFinalized(depositHash, success);
     }
 


### PR DESCRIPTION
# Goals of PR

Allow users to retry finalisation if the transaction fails. this automatically gives us retryability for the StandardBridge as well.

This should be safe since a transaction can only be replayed if it reverted and thus didn't cause a state change.  See [optimism implementation](https://github.com/ethereum-optimism/optimism/blob/05bacdc2af08c8ee16ddefcbf9c4f595e78c5f6f/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol#L283) for a similar check.