### PR TITLE
specular-config-generation: Mark as private

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "specular-config-generation",
   "version": "1.0.0",
+  "private": true,
   "description": "utils to generate configuration for the specular mono repo",
   "main": "index.js",
   "author": "Specular contributors",


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add `"private": true` to the `specular-config-generation` package.
