### PR TITLE
fix appendTxBatch signature and preserve exit code

### DIFF
--- a/contracts/scripts/e2e/bridge/test_standard_bridge_erc20.ts
+++ b/contracts/scripts/e2e/bridge/test_standard_bridge_erc20.ts
@@ -122,7 +122,7 @@ async function main() {
     inbox.filters.TxBatchAppended(),
     async (batchNumber, previousInboxSize, inboxSize, event) => {
       const tx = await event.getTransaction();
-      lastConfirmedBlockNumber = getLastBlockNumber(tx.data, inbox);
+      lastConfirmedBlockNumber = await getLastBlockNumber(tx.data);
     }
   );
 

--- a/contracts/scripts/e2e/bridge/test_standard_bridge_withdraw_eth.ts
+++ b/contracts/scripts/e2e/bridge/test_standard_bridge_withdraw_eth.ts
@@ -55,7 +55,7 @@ async function main() {
     inbox.filters.TxBatchAppended(),
     async (batchNumber, previousInboxSize, inboxSize, event) => {
       const tx = await event.getTransaction();
-      lastConfirmedBlockNumber = getLastBlockNumber(tx.data, inbox);
+      lastConfirmedBlockNumber = await getLastBlockNumber(tx.data);
     }
   );
 

--- a/contracts/scripts/e2e/utils.ts
+++ b/contracts/scripts/e2e/utils.ts
@@ -161,13 +161,13 @@ export function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function getLastBlockNumber(data) {
+export async function getLastBlockNumber(data) {
   // TODO: consider using the npm bindings package
-  const iface = new ethers.utils.Interface([
-    "function appendTxBatch(uint256[],uint256[],uint256,uint256,bytes)",
-  ]);
+  const InboxFactory = await ethers.getContractFactory("SequencerInbox");
+  const iface = InboxFactory.interface;
+
   const decoded = iface.decodeFunctionData(
-    "appendTxBatch(uint256[],uint256[],uint256,uint256,bytes)",
+    data.slice(0, 10), // method id (8 hex chars) with leading Ox
     data
   );
   const contexts: BigNumber[] = decoded[0];

--- a/contracts/scripts/e2e/utils.ts
+++ b/contracts/scripts/e2e/utils.ts
@@ -162,11 +162,12 @@ export function delay(ms: number) {
 }
 
 export function getLastBlockNumber(data) {
+  // TODO: consider using the npm bindings package
   const iface = new ethers.utils.Interface([
-    "function appendTxBatch(uint256[],uint256[],uint256,bytes)",
+    "function appendTxBatch(uint256[],uint256[],uint256,uint256,bytes)",
   ]);
   const decoded = iface.decodeFunctionData(
-    "appendTxBatch(uint256[],uint256[],uint256,bytes)",
+    "appendTxBatch(uint256[],uint256[],uint256,uint256,bytes)",
     data
   );
   const contexts: BigNumber[] = decoded[0];

--- a/e2e/sbin/test.sh
+++ b/e2e/sbin/test.sh
@@ -52,31 +52,30 @@ $SBIN_DIR/wait-for-it.sh -t 60 $HOST:$L2_HTTP_PORT
 cd $CONTRACTS_DIR
 npx hardhat deploy --network specularLocalDev | sed "s/^/[L2] /"
 
-
 case $1 in
-
   transactions)
-    npx hardhat run scripts/e2e/test_transactions.ts | sed "s/^/[TEST] /"
+    npx hardhat run scripts/e2e/test_transactions.ts
     RESULT=$?
     ;;
 
   deposit)
-    npx hardhat run scripts/e2e/bridge/test_standard_bridge_deposit_eth.ts | sed "s/^/[TEST] /"
+    npx hardhat run scripts/e2e/bridge/test_standard_bridge_deposit_eth.ts
     RESULT=$?
     ;;
 
   withdraw)
-    npx hardhat run scripts/e2e/bridge/test_standard_bridge_withdraw_eth.ts | sed "s/^/[TEST] /"
-   RESULT=$?
+    npx hardhat run scripts/e2e/bridge/test_standard_bridge_withdraw_eth.ts
+    RESULT=$?
     ;;
 
   erc20)
-    npx hardhat run scripts/e2e/bridge/test_standard_bridge_erc20.ts | sed "s/^/[TEST] /"
+    npx hardhat run scripts/e2e/bridge/test_standard_bridge_erc20.ts
     RESULT=$?
     ;;
 
   *)
     echo "unknown test"
+    RESULT=1
     ;;
 esac
 


### PR DESCRIPTION
# Goals of PR

- Removes hardcoded ABI from test script.
- Removes log prefix when running test script to preserve exit code.

Comment: The same change could be implemented in the relayer TS service where it is originally from.
