### PR TITLE
initial blob format contracts

### DIFF
--- a/contracts/src/ISequencerInbox.sol
+++ b/contracts/src/ISequencerInbox.sol
@@ -44,17 +44,10 @@ interface ISequencerInbox is IDAProvider {
 
     /**
      * @notice Appends a batch of transactions (stored in calldata) and emits a TxBatchAppended event.
-     * @param contexts Array of contexts, where each context is represented by a uint256 2-tuple:
-     * (numTxs, l2Timestamp). Each context corresponds to a single "L2 block".
-     * @param txLengths Array of lengths of each encoded tx in txBatch.
-     * @param firstL2BlockNumber The block number of the first "L2 block" included in this batch.
      * @param txBatchVersion The serialization version of the submitted tx batch
      * @param txBatch Batch of RLP-encoded transactions.
      */
     function appendTxBatch(
-        uint256[] calldata contexts,
-        uint256[] calldata txLengths,
-        uint256 firstL2BlockNumber,
         uint256 txBatchVersion,
         bytes calldata txBatch
     ) external;

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -74,9 +74,6 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
 
     /// @inheritdoc ISequencerInbox
     function appendTxBatch(
-        uint256[] calldata contexts,
-        uint256[] calldata txLengths,
-        uint256 firstL2BlockNumber,
         uint256 txBatchVersion,
         bytes calldata txBatch
     ) external override whenNotPaused {
@@ -88,46 +85,46 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
             revert TxBatchVersionIncorrect();
         }
 
-        uint256 numTxs = inboxSize;
-        bytes32 runningAccumulator;
-        if (accumulators.length > 0) {
-            runningAccumulator = accumulators[accumulators.length - 1];
-        }
+        // uint256 numTxs = inboxSize;
+        // bytes32 runningAccumulator;
+        // if (accumulators.length > 0) {
+        //     runningAccumulator = accumulators[accumulators.length - 1];
+        // }
 
-        uint256 dataOffset = 0;
-        uint256 l2BlockNumber = firstL2BlockNumber;
+        // uint256 dataOffset = 0;
+        // uint256 l2BlockNumber = firstL2BlockNumber;
 
-        for (uint256 i = 0; i + 2 <= contexts.length; i += 2) {
-            // TODO: consider adding L1 context.
-            uint256 l2Timestamp = contexts[i + 1];
-            bytes32 txContextHash = keccak256(abi.encodePacked(sequencerAddress, l2BlockNumber, l2Timestamp));
+        // for (uint256 i = 0; i + 2 <= contexts.length; i += 2) {
+        //     // TODO: consider adding L1 context.
+        //     uint256 l2Timestamp = contexts[i + 1];
+        //     bytes32 txContextHash = keccak256(abi.encodePacked(sequencerAddress, l2BlockNumber, l2Timestamp));
 
-            uint256 numCtxTxs = contexts[i];
+        //     uint256 numCtxTxs = contexts[i];
 
-            for (uint256 j = 0; j < numCtxTxs; j++) {
-                uint256 txLength = txLengths[numTxs - inboxSize];
-                if (dataOffset + txLength > txBatch.length) {
-                    revert TxBatchDataOverflow();
-                }
-                bytes32 txDataHash = keccak256(txBatch[dataOffset:dataOffset + txLength]);
+        //     for (uint256 j = 0; j < numCtxTxs; j++) {
+        //         uint256 txLength = txLengths[numTxs - inboxSize];
+        //         if (dataOffset + txLength > txBatch.length) {
+        //             revert TxBatchDataOverflow();
+        //         }
+        //         bytes32 txDataHash = keccak256(txBatch[dataOffset:dataOffset + txLength]);
 
-                runningAccumulator = keccak256(abi.encodePacked(runningAccumulator, numTxs, txContextHash, txDataHash));
+        //         runningAccumulator = keccak256(abi.encodePacked(runningAccumulator, numTxs, txContextHash, txDataHash));
 
-                dataOffset += txLength;
-                numTxs++;
-            }
+        //         dataOffset += txLength;
+        //         numTxs++;
+        //     }
 
-            // block numbers get incremented by one
-            // we can reconstruct all block numbers of the batch since we know the first one
-            l2BlockNumber++;
-        }
+        //     // block numbers get incremented by one
+        //     // we can reconstruct all block numbers of the batch since we know the first one
+        //     l2BlockNumber++;
+        // }
 
-        if (numTxs <= inboxSize) revert EmptyBatch();
-        uint256 start = inboxSize;
-        inboxSize = numTxs;
-        accumulators.push(runningAccumulator);
+        // if (numTxs <= inboxSize) revert EmptyBatch();
+        // uint256 start = inboxSize;
+        // inboxSize = numTxs;
+        // accumulators.push(runningAccumulator);
 
-        emit TxBatchAppended(accumulators.length - 1, start, inboxSize);
+        emit TxBatchAppended(0, 0, inboxSize);
     }
 
     // TODO post EIP-4844: KZG proof verification

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -1341,7 +1341,7 @@ contract RollupTest is RollupBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 seqInboxSizeFinal = seqIn.getInboxSize();
         assertEq(seqInboxSizeFinal, seqInboxSizeInitial + 6, "Sequencer inbox size did not increase by 6");

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -91,19 +91,15 @@ contract SequencerInboxTest is SequencerBaseSetup {
     function test_appendTxBatch_invalidSequencer_reverts() public {
         vm.expectRevert(abi.encodeWithSelector(NotSequencer.selector, alice, sequencerAddress));
         vm.prank(alice);
-        uint256[] memory contexts = new uint256[](1);
-        uint256[] memory txLengths = new uint256[](1);
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(contexts, txLengths, 1, txBatchVersion, "0x");
+        seqIn.appendTxBatch(txBatchVersion, "0x");
     }
 
     function test_appendTxBatch_emptyBatch_reverts() public {
         vm.expectRevert(ISequencerInbox.EmptyBatch.selector);
         vm.prank(sequencerAddress);
-        uint256[] memory contexts = new uint256[](1);
-        uint256[] memory txLengths = new uint256[](1);
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(contexts, txLengths, 1, txBatchVersion, "0x");
+        seqIn.appendTxBatch(txBatchVersion, "0x");
     }
 
     //////////////////////////////
@@ -149,7 +145,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
         assertGt(inboxSizeFinal, inboxSizeInitial);
@@ -191,7 +187,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 
@@ -244,7 +240,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // Pranking as the sequencer and calling appendTxBatch (should throw the TxBatchDataOverflow error)
         vm.expectRevert(ISequencerInbox.TxBatchDataOverflow.selector);
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
     }
 
     function test_appendTxBatch_paused_reverts(uint256 numTxnsPerBlock, uint256 txnBlocks) public {
@@ -289,7 +285,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
         vm.expectRevert("Pausable: paused");
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////
@@ -323,7 +319,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 
@@ -350,7 +346,7 @@ contract SequencerInboxTest is SequencerBaseSetup {
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, 0, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
         assertEq(seqIn.getInboxSize(), numTx);
 
         // randomly choose a transaction to verify and prepare the proof


### PR DESCRIPTION
# Goals of PR

Create initial interface for batch data format

Core changes:

Change the signature of appendTxBatch

```
function appendTxBatch(    
        uint256 txBatchVersion,
        bytes calldata txBatch,
    ) external;
```
where:

```
txBatch = rlp([first_l2_block_number, blocks]), 

block = [timestamp, transaction_list]; blocks = [block1, block2, ...],
transaction_list = [tx1, tx2, ...].
```

Notes:

We could also encode `txBatchVersion` in the first byte of `txBatch` and remove the `txBatchVersion` argument.

```
txBatch = txBatchVersion ++ rlp([first_l2_block_number, blocks]), 

block = [timestamp, transaction_list]; blocks = [block1, block2, ...],
```