### PR TITLE
publish txBatch blob

### DIFF
--- a/clients/geth/specular/go.mod
+++ b/clients/geth/specular/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/urfave/cli/v2 v2.10.2
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (
@@ -72,7 +73,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect

--- a/clients/geth/specular/rollup/derivation/batch_builder.go
+++ b/clients/geth/specular/rollup/derivation/batch_builder.go
@@ -31,7 +31,7 @@ type BatchAttributes struct {
 }
 
 // TODO: find a better place to not hardcode this
-func TxBatchVersion() *big.Int { return big.NewInt(0) }
+func TxBatchVersion() byte { return byte(0x00) }
 
 type HeaderRef interface {
 	GetHash() common.Hash

--- a/clients/geth/specular/rollup/derivation/derivation_block.go
+++ b/clients/geth/specular/rollup/derivation/derivation_block.go
@@ -1,8 +1,9 @@
 package derivation
 
 import (
-	"math/big"
+	"bytes"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/specularl2/specular/clients/geth/specular/utils/fmt"
 	"github.com/specularl2/specular/clients/geth/specular/utils/log"
 )
@@ -48,41 +49,30 @@ func (e *DecodeTxBatchError) Error() string {
 
 // Decodes the input of `SequencerInbox.appendTxBatch` call
 func BlocksFromData(calldata []any) ([]DerivationBlock, error) {
-	if len(calldata) != 4 {
+	if len(calldata) != 2 {
 		return nil, &DecodeTxBatchError{fmt.Sprintf("invalid decoded array length %d", len(calldata))}
 	}
 	var (
-		contexts           = calldata[0].([]*big.Int)
-		txLengths          = calldata[1].([]*big.Int)
-		firstL2BlockNumber = calldata[2].(*big.Int)
 		// TODO: commented until multiple versions have been used
-		//txBatchVersion     = calldata[3].(*big.Int)
-		txBatch = calldata[4].([]byte)
+		//txBatchVersion     = calldata[0].(*big.Int)
+		txBatch = calldata[1].([]byte)
 	)
-	if len(contexts)%2 != 0 {
-		return nil, &DecodeTxBatchError{fmt.Sprintf("invalid contexts length %d", len(contexts))}
+
+	var decodedBatch BatchAttributes
+	if err := rlp.Decode(bytes.NewReader(txBatch), &decodedBatch); err != nil {
+		return nil, err
 	}
-	var (
-		batchOffset, numTxs uint64
-		blocks              = make([]DerivationBlock, 0, len(contexts)/2)
-		blockNumber         = firstL2BlockNumber.Uint64()
-	)
-	for i := 0; i < len(contexts); i += 2 {
+
+	blocks := make([]DerivationBlock, 0, len(decodedBatch.Blocks))
+	for i, block := range decodedBatch.Blocks {
 		// For each context, decode a block.
 		ctx := DerivationContext{
-			numTxs:      contexts[i].Uint64(),
-			blockNumber: blockNumber + uint64(i),
-			timestamp:   contexts[i+1].Uint64(),
-		}
-		var txs [][]byte
-		for j := uint64(0); j < ctx.numTxs; j++ {
-			encodedTx := txBatch[batchOffset : batchOffset+txLengths[numTxs].Uint64()]
-			txs = append(txs, encodedTx)
-			numTxs++
-			batchOffset += txLengths[numTxs-1].Uint64()
+			numTxs:      uint64(len(block.Txs)),
+			blockNumber: decodedBatch.FirstL2BlockNumber.Uint64() + uint64(i),
+			timestamp:   block.Timestamp.Uint64(),
 		}
 		log.Trace("Block decoded", "block#", ctx.blockNumber, "numTxs", ctx.numTxs)
-		blocks = append(blocks, DerivationBlock{ctx, txs})
+		blocks = append(blocks, DerivationBlock{ctx, block.Txs})
 	}
 	return blocks, nil
 }

--- a/clients/geth/specular/rollup/rpc/bridge/serialization.go
+++ b/clients/geth/specular/rollup/rpc/bridge/serialization.go
@@ -51,8 +51,8 @@ func UnpackAppendTxBatchInput(tx *types.Transaction) ([]any, error) {
 	return serializationUtil.inboxAbi.Methods[AppendTxBatchFnName].Inputs.Unpack(tx.Data()[MethodNumBytes:])
 }
 
-func packAppendTxBatchInput(txBatchVersion *big.Int, txBatch []byte) ([]byte, error) {
-	return serializationUtil.inboxAbi.Pack(AppendTxBatchFnName, txBatchVersion, txBatch)
+func packAppendTxBatchInput(txBatchData []byte) ([]byte, error) {
+	return serializationUtil.inboxAbi.Pack(AppendTxBatchFnName, txBatchData)
 }
 
 // IRollup.sol

--- a/clients/geth/specular/rollup/rpc/bridge/serialization.go
+++ b/clients/geth/specular/rollup/rpc/bridge/serialization.go
@@ -51,8 +51,8 @@ func UnpackAppendTxBatchInput(tx *types.Transaction) ([]any, error) {
 	return serializationUtil.inboxAbi.Methods[AppendTxBatchFnName].Inputs.Unpack(tx.Data()[MethodNumBytes:])
 }
 
-func packAppendTxBatchInput(contexts, txLengths []*big.Int, firstL2BlockNumber *big.Int, txBatchVersion *big.Int, txs []byte) ([]byte, error) {
-	return serializationUtil.inboxAbi.Pack(AppendTxBatchFnName, contexts, txLengths, firstL2BlockNumber, txBatchVersion, txs)
+func packAppendTxBatchInput(txBatchVersion *big.Int, txBatch []byte) ([]byte, error) {
+	return serializationUtil.inboxAbi.Pack(AppendTxBatchFnName, txBatchVersion, txBatch)
 }
 
 // IRollup.sol

--- a/clients/geth/specular/rollup/rpc/bridge/tx_mgr.go
+++ b/clients/geth/specular/rollup/rpc/bridge/tx_mgr.go
@@ -33,13 +33,10 @@ func NewTxManager(txMgr EthTxManager, cfg bridgeConfig) (*TxManager, error) {
 
 func (m *TxManager) AppendTxBatch(
 	ctx context.Context,
-	contexts,
-	txLengths []*big.Int,
-	firstL2BlockNumber *big.Int,
 	txBatchVersion *big.Int,
-	txs []byte,
+	txBatch []byte,
 ) (*types.Receipt, error) {
-	data, err := packAppendTxBatchInput(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txs)
+	data, err := packAppendTxBatchInput(txBatchVersion, txBatch)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/geth/specular/rollup/rpc/bridge/tx_mgr.go
+++ b/clients/geth/specular/rollup/rpc/bridge/tx_mgr.go
@@ -33,10 +33,9 @@ func NewTxManager(txMgr EthTxManager, cfg bridgeConfig) (*TxManager, error) {
 
 func (m *TxManager) AppendTxBatch(
 	ctx context.Context,
-	txBatchVersion *big.Int,
 	txBatch []byte,
 ) (*types.Receipt, error) {
-	data, err := packAppendTxBatchInput(txBatchVersion, txBatch)
+	data, err := packAppendTxBatchInput(txBatch)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/geth/specular/rollup/services/disseminator/batch_disseminator.go
+++ b/clients/geth/specular/rollup/services/disseminator/batch_disseminator.go
@@ -191,11 +191,17 @@ func (d *BatchDisseminator) disseminateBatch(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to build batch: %w", err)
 	}
-	bytes, err := rlp.EncodeToBytes(batchAttrs)
+	rlpBatchData, err := rlp.EncodeToBytes(batchAttrs)
 	if err != nil {
 		return fmt.Errorf("failed to encode batch: %w", err)
 	}
-	receipt, err := d.l1TxMgr.AppendTxBatch(ctx, derivation.TxBatchVersion(), bytes)
+
+	// Prepend batch data with version
+	txBatchData := make([]byte, len(rlpBatchData)+1)
+	txBatchData[0] = derivation.TxBatchVersion()
+	copy(txBatchData[1:], rlpBatchData)
+
+	receipt, err := d.l1TxMgr.AppendTxBatch(ctx, txBatchData)
 	if err != nil {
 		return fmt.Errorf("failed to send batch transaction: %w", err)
 	}

--- a/clients/geth/specular/rollup/services/disseminator/batch_disseminator.go
+++ b/clients/geth/specular/rollup/services/disseminator/batch_disseminator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/derivation"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/rpc/eth"
 	"github.com/specularl2/specular/clients/geth/specular/rollup/services/api"
@@ -190,14 +191,11 @@ func (d *BatchDisseminator) disseminateBatch(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to build batch: %w", err)
 	}
-	receipt, err := d.l1TxMgr.AppendTxBatch(
-		ctx,
-		batchAttrs.Contexts(),
-		batchAttrs.TxLengths(),
-		batchAttrs.FirstL2BlockNumber(),
-		batchAttrs.TxBatchVersion(),
-		batchAttrs.TxBatch(),
-	)
+	bytes, err := rlp.EncodeToBytes(batchAttrs)
+	if err != nil {
+		return fmt.Errorf("failed to encode batch: %w", err)
+	}
+	receipt, err := d.l1TxMgr.AppendTxBatch(ctx, derivation.TxBatchVersion(), bytes)
 	if err != nil {
 		return fmt.Errorf("failed to send batch transaction: %w", err)
 	}

--- a/clients/geth/specular/rollup/services/disseminator/interface.go
+++ b/clients/geth/specular/rollup/services/disseminator/interface.go
@@ -29,7 +29,6 @@ type BatchBuilder interface {
 type TxManager interface {
 	AppendTxBatch(
 		ctx context.Context,
-		version *big.Int,
 		batchData []byte,
 	) (*ethTypes.Receipt, error)
 }

--- a/clients/geth/specular/rollup/services/disseminator/interface.go
+++ b/clients/geth/specular/rollup/services/disseminator/interface.go
@@ -29,11 +29,8 @@ type BatchBuilder interface {
 type TxManager interface {
 	AppendTxBatch(
 		ctx context.Context,
-		contexts []*big.Int,
-		txLengths []*big.Int,
-		firstL2BlockNumber *big.Int,
-		txBatchVersion *big.Int,
-		txBatch []byte,
+		version *big.Int,
+		batchData []byte,
 	) (*ethTypes.Receipt, error)
 }
 

--- a/contracts/src/ISequencerInbox.sol
+++ b/contracts/src/ISequencerInbox.sol
@@ -30,25 +30,26 @@ import "./IDAProvider.sol";
 interface ISequencerInbox is IDAProvider {
     event TxBatchAppended(uint256 batchNumber);
 
-    /// @dev Thrown when the given tx inlcusion proof couldn't be verified.
+    /// @dev Thrown when the given tx inclusion proof couldn't be verified.
     error ProofVerificationFailed();
 
     /// @dev Thrown when sequencer tries to append an empty batch
     error EmptyBatch();
 
-    /// @dev Thrown when overflow occurs reading txBatch (likely due to malformed txLengths)
+    /// @dev Thrown when underflow occurs reading txBatch
+    error TxBatchDataUnderflow();
+
+    /// @dev Thrown when overflow occurs reading txBatch
     error TxBatchDataOverflow();
 
-    /// @dev Thrown when overflow occurs reading txBatch (likely due to malformed txLengths)
+    /// @dev Thrown when a transaction batch has an incorrect version
     error TxBatchVersionIncorrect();
 
     /**
      * @notice Appends a batch of transactions (stored in calldata) and emits a TxBatchAppended event.
-     * @param txBatchVersion The serialization version of the submitted tx batch
-     * @param txBatch Batch of RLP-encoded transactions.
+     * @param txBatchData Batch of RLP-encoded transactions.
      */
     function appendTxBatch(
-        uint256 txBatchVersion,
-        bytes calldata txBatch
+        bytes calldata txBatchData
     ) external;
 }

--- a/contracts/src/ISequencerInbox.sol
+++ b/contracts/src/ISequencerInbox.sol
@@ -28,7 +28,7 @@ import "./IDAProvider.sol";
  * @notice On-chain DA provider.
  */
 interface ISequencerInbox is IDAProvider {
-    event TxBatchAppended(uint256 batchNumber, uint256 startTxNumber, uint256 endTxNumber);
+    event TxBatchAppended(uint256 batchNumber);
 
     /// @dev Thrown when the given tx inlcusion proof couldn't be verified.
     error ProofVerificationFailed();
@@ -44,17 +44,10 @@ interface ISequencerInbox is IDAProvider {
 
     /**
      * @notice Appends a batch of transactions (stored in calldata) and emits a TxBatchAppended event.
-     * @param contexts Array of contexts, where each context is represented by a uint256 2-tuple:
-     * (numTxs, l2Timestamp). Each context corresponds to a single "L2 block".
-     * @param txLengths Array of lengths of each encoded tx in txBatch.
-     * @param firstL2BlockNumber The block number of the first "L2 block" included in this batch.
      * @param txBatchVersion The serialization version of the submitted tx batch
      * @param txBatch Batch of RLP-encoded transactions.
      */
     function appendTxBatch(
-        uint256[] calldata contexts,
-        uint256[] calldata txLengths,
-        uint256 firstL2BlockNumber,
         uint256 txBatchVersion,
         bytes calldata txBatch
     ) external;

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -38,7 +38,7 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
     bytes32[] public accumulators;
 
     // Current txBatch serialization version
-    uint256 public constant currentTxBatchVersion = 0;
+    uint8 public constant currentTxBatchVersion = 0;
 
     address public sequencerAddress;
 
@@ -74,13 +74,17 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
 
     /// @inheritdoc ISequencerInbox
     function appendTxBatch(
-        uint256 txBatchVersion,
-        bytes calldata 
+        bytes calldata txBatchData
     ) external override whenNotPaused {
         if (msg.sender != sequencerAddress) {
             revert NotSequencer(msg.sender, sequencerAddress);
         }
 
+        if (txBatchData.length == 0) {
+            revert TxBatchDataUnderflow();
+        }
+
+        uint8 txBatchVersion = uint8(txBatchData[0]);
         if (txBatchVersion != currentTxBatchVersion) {
             revert TxBatchVersionIncorrect();
         }

--- a/contracts/src/SequencerInbox.sol
+++ b/contracts/src/SequencerInbox.sol
@@ -74,11 +74,8 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
 
     /// @inheritdoc ISequencerInbox
     function appendTxBatch(
-        uint256[] calldata contexts,
-        uint256[] calldata txLengths,
-        uint256 firstL2BlockNumber,
         uint256 txBatchVersion,
-        bytes calldata txBatch
+        bytes calldata 
     ) external override whenNotPaused {
         if (msg.sender != sequencerAddress) {
             revert NotSequencer(msg.sender, sequencerAddress);
@@ -88,46 +85,47 @@ contract SequencerInbox is ISequencerInbox, Initializable, UUPSUpgradeable, Owna
             revert TxBatchVersionIncorrect();
         }
 
-        uint256 numTxs = inboxSize;
-        bytes32 runningAccumulator;
-        if (accumulators.length > 0) {
-            runningAccumulator = accumulators[accumulators.length - 1];
-        }
+        // uint256 numTxs = inboxSize;
+        // bytes32 runningAccumulator;
+        // if (accumulators.length > 0) {
+        //     runningAccumulator = accumulators[accumulators.length - 1];
+        // }
 
-        uint256 dataOffset = 0;
-        uint256 l2BlockNumber = firstL2BlockNumber;
+        // uint256 dataOffset = 0;
+        // uint256 l2BlockNumber = firstL2BlockNumber;
 
-        for (uint256 i = 0; i + 2 <= contexts.length; i += 2) {
-            // TODO: consider adding L1 context.
-            uint256 l2Timestamp = contexts[i + 1];
-            bytes32 txContextHash = keccak256(abi.encodePacked(sequencerAddress, l2BlockNumber, l2Timestamp));
+        // for (uint256 i = 0; i + 2 <= contexts.length; i += 2) {
+        //     // TODO: consider adding L1 context.
+        //     uint256 l2Timestamp = contexts[i + 1];
+        //     bytes32 txContextHash = keccak256(abi.encodePacked(sequencerAddress, l2BlockNumber, l2Timestamp));
 
-            uint256 numCtxTxs = contexts[i];
+        //     uint256 numCtxTxs = contexts[i];
 
-            for (uint256 j = 0; j < numCtxTxs; j++) {
-                uint256 txLength = txLengths[numTxs - inboxSize];
-                if (dataOffset + txLength > txBatch.length) {
-                    revert TxBatchDataOverflow();
-                }
-                bytes32 txDataHash = keccak256(txBatch[dataOffset:dataOffset + txLength]);
+        //     for (uint256 j = 0; j < numCtxTxs; j++) {
+        //         uint256 txLength = txLengths[numTxs - inboxSize];
+        //         if (dataOffset + txLength > txBatch.length) {
+        //             revert TxBatchDataOverflow();
+        //         }
+        //         bytes32 txDataHash = keccak256(txBatch[dataOffset:dataOffset + txLength]);
 
-                runningAccumulator = keccak256(abi.encodePacked(runningAccumulator, numTxs, txContextHash, txDataHash));
+        //         runningAccumulator = keccak256(abi.encodePacked(runningAccumulator, numTxs, txContextHash, txDataHash));
 
-                dataOffset += txLength;
-                numTxs++;
-            }
+        //         dataOffset += txLength;
+        //         numTxs++;
+        //     }
 
-            // block numbers get incremented by one
-            // we can reconstruct all block numbers of the batch since we know the first one
-            l2BlockNumber++;
-        }
+        //     // block numbers get incremented by one
+        //     // we can reconstruct all block numbers of the batch since we know the first one
+        //     l2BlockNumber++;
+        // }
 
-        if (numTxs <= inboxSize) revert EmptyBatch();
-        uint256 start = inboxSize;
-        inboxSize = numTxs;
-        accumulators.push(runningAccumulator);
+        // if (numTxs <= inboxSize) revert EmptyBatch();
+        // uint256 start = inboxSize;
+        // inboxSize = numTxs;
+        // accumulators.push(runningAccumulator);
 
-        emit TxBatchAppended(accumulators.length - 1, start, inboxSize);
+        inboxSize = inboxSize + 1;
+        emit TxBatchAppended(inboxSize);
     }
 
     // TODO post EIP-4844: KZG proof verification

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -1310,11 +1310,10 @@ contract RollupTest is RollupBaseSetup {
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
         bytes memory txBatch = _helper_createTxBatch_hardcoded();
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatch);
 
         uint256 seqInboxSizeFinal = seqIn.getInboxSize();
         assertEq(seqInboxSizeFinal, seqInboxSizeInitial + 1, "Sequencer inbox size did not increment");

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -235,7 +235,7 @@ contract RollupTest is RollupBaseSetup {
     // Admin
     ///////////////
 
-    function testFuzz_addValidators_succeeds() external {
+    function test_addValidators_succeeds() external {
         // Initialize rollup with an empty validator whitelist
         _initializeRollup(
             0, // confirmationPeriod
@@ -243,7 +243,7 @@ contract RollupTest is RollupBaseSetup {
             0, // minimumAssertionPeriod
             1, // baseStakeAmount,
             0, // initialAssertionID
-            0, // initialInboxSize
+            0, // initialInboxBox
             new address[](0) // validator whitelist
         );
 
@@ -269,7 +269,7 @@ contract RollupTest is RollupBaseSetup {
         assertFalse(rollup.hasRole(rollup.VALIDATOR_ROLE(), bob), "Expected address not to be in validator whitelist");
     }
 
-    function testFuzz_removeValidators_succeeds() external {
+    function test_removeValidators_succeeds() external {
         // Initialize rollup with alice in the validator whitelist
         address[] memory validators = new address[](1);
         validators[0] = alice;
@@ -302,7 +302,7 @@ contract RollupTest is RollupBaseSetup {
         assertFalse(rollup.hasRole(rollup.VALIDATOR_ROLE(), alice), "Expected address to be in validator whitelist");
     }
 
-    function testFuzz_removeOwnValidatorRole_succeeds() external {
+    function test_removeOwnValidatorRole_succeeds() external {
         address[] memory validators = new address[](1);
         validators[0] = alice;
         // Initialize rollup with alice in validator whitelist
@@ -407,16 +407,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             baseStakeAmount,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -428,16 +426,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             type(uint256).max,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -461,11 +457,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID
         );
 
         uint256 initialStakers = rollup.numStakers();
@@ -497,11 +492,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID
         );
 
         uint256 initialStakers = rollup.numStakers();
@@ -536,11 +530,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1000, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -605,16 +598,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             baseStakeAmount,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -633,16 +624,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             baseStakeAmount,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -660,11 +649,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -695,11 +683,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 confirmationPeriod,
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -736,7 +723,7 @@ contract RollupTest is RollupBaseSetup {
     ) external {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
-        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0, 5);
+        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0);
 
         uint256 minimumAmount = rollup.baseStakeAmount();
         uint256 aliceBalance = alice.balance;
@@ -758,7 +745,7 @@ contract RollupTest is RollupBaseSetup {
         _increaseSequencerInboxSize();
 
         bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 6;
+        uint256 mockInboxSize = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -792,16 +779,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             baseStakeAmount,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -819,11 +804,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 amountToWithdraw,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -852,11 +836,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 amountToWithdraw,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -890,11 +873,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 amountToWithdraw,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 100000, initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -924,7 +906,7 @@ contract RollupTest is RollupBaseSetup {
     {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
-        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0, 5);
+        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0);
 
         uint256 minimumAmount = rollup.baseStakeAmount();
         uint256 aliceBalance = alice.balance;
@@ -941,7 +923,7 @@ contract RollupTest is RollupBaseSetup {
         _increaseSequencerInboxSize();
 
         bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 6;
+        uint256 mockInboxSize = 1;
 
         vm.prank(alice);
         rollup.createAssertion(mockVmHash, mockInboxSize);
@@ -966,16 +948,14 @@ contract RollupTest is RollupBaseSetup {
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
         uint256 assertionID,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
             confirmationPeriod,
             challengePeriod,
             minimumAssertionPeriod,
             baseStakeAmount,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         // Alice has not staked yet and therefore, this function should return `false`
@@ -994,11 +974,10 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 assertionID,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) external {
         _initializeRollup(
-            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID, initialInboxSize
+            confirmationPeriod, challengePeriod, minimumAssertionPeriod, 1 ether, initialAssertionID
         );
 
         uint256 minimumAmount = rollup.baseStakeAmount();
@@ -1019,7 +998,7 @@ contract RollupTest is RollupBaseSetup {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
 
-        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0, 5);
+        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0);
 
         uint256 minimumAmount = rollup.baseStakeAmount();
 
@@ -1042,7 +1021,7 @@ contract RollupTest is RollupBaseSetup {
         _increaseSequencerInboxSize();
 
         bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 6;
+        uint256 mockInboxSize = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -1085,7 +1064,7 @@ contract RollupTest is RollupBaseSetup {
         // Bounding it otherwise, function `newAssertionDeadline()` overflows
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
 
-        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0, 5);
+        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0);
 
         uint256 minimumAmount = rollup.baseStakeAmount();
 
@@ -1108,7 +1087,7 @@ contract RollupTest is RollupBaseSetup {
         _increaseSequencerInboxSize();
 
         bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 6;
+        uint256 mockInboxSize = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -1175,8 +1154,7 @@ contract RollupTest is RollupBaseSetup {
         uint256 minimumAssertionPeriod,
         uint256 defenderAssertionID,
         uint256 challengerAssertionID,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) public {
         // Initializing the rollup
         _initializeRollup(
@@ -1184,8 +1162,7 @@ contract RollupTest is RollupBaseSetup {
             challengePeriod,
             minimumAssertionPeriod,
             type(uint256).max,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         defenderAssertionID = bound(defenderAssertionID, challengerAssertionID, type(uint256).max);
@@ -1209,7 +1186,6 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 initialAssertionID,
-        uint256 initialInboxSize,
         uint256 challengerAssertionID,
         uint256 defenderAssertionID
     ) public {
@@ -1220,8 +1196,7 @@ contract RollupTest is RollupBaseSetup {
             challengePeriod,
             minimumAssertionPeriod,
             type(uint256).max,
-            initialAssertionID,
-            initialInboxSize
+            initialAssertionID
         );
 
         uint256 lastCreatedAssertionID = rollup.lastCreatedAssertionID();
@@ -1249,7 +1224,7 @@ contract RollupTest is RollupBaseSetup {
     ) public {
         // Initializing the rollup
         confirmationPeriod = bound(confirmationPeriod, 1, type(uint128).max);
-        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0, 5);
+        _initializeRollup(confirmationPeriod, challengePeriod, 1 days, 1 ether, 0);
 
         uint256 lastConfirmedAssertionID = rollup.lastConfirmedAssertionID();
 
@@ -1267,7 +1242,7 @@ contract RollupTest is RollupBaseSetup {
             _increaseSequencerInboxSize();
 
             bytes32 mockVmHash = bytes32("");
-            uint256 mockInboxSize = 6;
+            uint256 mockInboxSize = 1;
 
             // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
             vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -1317,7 +1292,6 @@ contract RollupTest is RollupBaseSetup {
     function _increaseSequencerInboxSize() internal {
         uint256 seqInboxSizeInitial = seqIn.getInboxSize();
         uint256 numTxnsPerBlock = 3;
-        uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Each context corresponds to a single "L2 block"
         // `contexts` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
@@ -1336,15 +1310,14 @@ contract RollupTest is RollupBaseSetup {
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
         bytes memory txBatch = _helper_createTxBatch_hardcoded();
-        uint256[] memory txLengths = _helper_findTxLength_hardcoded();
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 seqInboxSizeFinal = seqIn.getInboxSize();
-        assertEq(seqInboxSizeFinal, seqInboxSizeInitial + 6, "Sequencer inbox size did not increase by 6");
+        assertEq(seqInboxSizeFinal, seqInboxSizeInitial + 1, "Sequencer inbox size did not increment");
     }
 
     function _initializeRollup(
@@ -1352,8 +1325,7 @@ contract RollupTest is RollupBaseSetup {
         uint256 challengePeriod,
         uint256 minimumAssertionPeriod,
         uint256 baseStakeAmount,
-        uint256 initialAssertionID,
-        uint256 initialInboxSize
+        uint256 initialAssertionID
     ) internal {
         address[] memory validators = new address[](2);
         validators[0] = alice;
@@ -1364,7 +1336,7 @@ contract RollupTest is RollupBaseSetup {
             minimumAssertionPeriod,
             baseStakeAmount,
             initialAssertionID,
-            initialInboxSize,
+            0, // initialInboxSize
             validators
         );
     }

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -91,16 +91,14 @@ contract SequencerInboxTest is SequencerBaseSetup {
     function test_appendTxBatch_invalidSequencer_reverts() public {
         vm.expectRevert(abi.encodeWithSelector(NotSequencer.selector, alice, sequencerAddress));
         vm.prank(alice);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(txBatchVersion, "0x");
+        seqIn.appendTxBatch(hex"00");
     }
 
     function test_appendTxBatch_emptyBatch_succeeds() public {
         uint256 inboxSizeInitial = seqIn.getInboxSize();
 
         vm.prank(sequencerAddress);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(txBatchVersion, "0x");
+        seqIn.appendTxBatch(hex"00");
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
         assertEq(inboxSizeFinal, inboxSizeInitial + 1); 
@@ -142,12 +140,11 @@ contract SequencerInboxTest is SequencerBaseSetup {
 
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
         bytes memory txBatch = _helper_sequencerInbox_appendTx(numTxns);
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
         assertGt(inboxSizeFinal, inboxSizeInitial);
@@ -172,12 +169,11 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // uint256 timeStamp2 = block.timestamp / 5;
 
         // txBatch is defined as: Batch of RLP-encoded transactions
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
         bytes memory txBatch = _helper_createTxBatch_hardcoded();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 
@@ -219,12 +215,11 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
         bytes memory txBatch = _helper_sequencerInbox_appendTx(numTxns);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
         vm.expectRevert("Pausable: paused");
-        seqIn.appendTxBatch(txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatch);
     }
 
     //////////////////////////////

--- a/contracts/test/SequencerInbox.t.sol
+++ b/contracts/test/SequencerInbox.t.sol
@@ -91,19 +91,19 @@ contract SequencerInboxTest is SequencerBaseSetup {
     function test_appendTxBatch_invalidSequencer_reverts() public {
         vm.expectRevert(abi.encodeWithSelector(NotSequencer.selector, alice, sequencerAddress));
         vm.prank(alice);
-        uint256[] memory contexts = new uint256[](1);
-        uint256[] memory txLengths = new uint256[](1);
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(contexts, txLengths, 1, txBatchVersion, "0x");
+        seqIn.appendTxBatch(txBatchVersion, "0x");
     }
 
-    function test_appendTxBatch_emptyBatch_reverts() public {
-        vm.expectRevert(ISequencerInbox.EmptyBatch.selector);
+    function test_appendTxBatch_emptyBatch_succeeds() public {
+        uint256 inboxSizeInitial = seqIn.getInboxSize();
+
         vm.prank(sequencerAddress);
-        uint256[] memory contexts = new uint256[](1);
-        uint256[] memory txLengths = new uint256[](1);
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        seqIn.appendTxBatch(contexts, txLengths, 1, txBatchVersion, "0x");
+        seqIn.appendTxBatch(txBatchVersion, "0x");
+
+        uint256 inboxSizeFinal = seqIn.getInboxSize();
+        assertEq(inboxSizeFinal, inboxSizeInitial + 1); 
     }
 
     //////////////////////////////
@@ -126,8 +126,6 @@ contract SequencerInboxTest is SequencerBaseSetup {
         uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
         // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
 
-        uint256 firstL2BlockNumber = block.timestamp / 20;
-
         // Let's create an array of contexts
         uint256[] memory contexts = new uint256[](numContextsArrEntries);
         for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
@@ -145,17 +143,16 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTxns);
+        bytes memory txBatch = _helper_sequencerInbox_appendTx(numTxns);
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
         assertGt(inboxSizeFinal, inboxSizeInitial);
 
-        uint256 expectedInboxSize = numTxns;
-        assertEq(inboxSizeFinal, expectedInboxSize);
+        assertEq(inboxSizeFinal, inboxSizeInitial + 1); 
     }
 
     function test_appendTxBatch_case2Hardcoded_succeeds() public {
@@ -163,88 +160,30 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // Here, we are assuming we have 2 transaction blocks with 3 transactions each (initial lower load hardcoded test)
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        uint256 numTxnsPerBlock = 3;
+        // uint256 numTxnsPerBlock = 3;
         uint256 inboxSizeInitial = seqIn.getInboxSize();
 
-        uint256 firstL2BlockNumber = block.timestamp / 20;
+        // uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Each context corresponds to a single "L2 block"
         // `contexts` is represented with uint256 2-tuple: (numTxs, l2Timestamp)
         // Let's create an array of contexts
-        uint256 numTxns = numTxnsPerBlock * 2;
-        uint256 timeStamp1 = block.timestamp / 10;
-        uint256 timeStamp2 = block.timestamp / 5;
+        // uint256 timeStamp1 = block.timestamp / 10;
+        // uint256 timeStamp2 = block.timestamp / 5;
 
-        uint256[] memory contexts = new uint256[](6);
-
-        // Let's assume that we had 2 blocks and each had 3 transactions
-        contexts[0] = (numTxnsPerBlock);
-        contexts[1] = (timeStamp1);
-        contexts[2] = (numTxnsPerBlock);
-        contexts[3] = (timeStamp2);
-
-        // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
         bytes memory txBatch = _helper_createTxBatch_hardcoded();
-        uint256[] memory txLengths = _helper_findTxLength_hardcoded();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
 
         uint256 inboxSizeFinal = seqIn.getInboxSize();
 
         assertGt(inboxSizeFinal, inboxSizeInitial);
 
-        uint256 expectedInboxSize = numTxns;
-        assertEq(inboxSizeFinal, expectedInboxSize);
-    }
-
-    function test_appendTxBatch_txBatchDataOverflow_reverts(uint256 numTxnsPerBlock, uint256 txnBlocks) public {
-        // We will operate at a limit of transactionsPerBlock = 30 and number of transactionBlocks = 10.
-        numTxnsPerBlock = bound(numTxnsPerBlock, 1, 30);
-        txnBlocks = bound(txnBlocks, 1, 10);
-
-        // Each context corresponds to a single "L2 block"
-        uint256 numTxns = numTxnsPerBlock * txnBlocks;
-        uint256 numContextsArrEntries = 2 * txnBlocks; // Since each `context` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
-
-        // Making sure that the block.timestamp is a reasonable value (> txnBlocks)
-        vm.warp(block.timestamp + (4 * txnBlocks));
-        uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
-        // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
-
-        uint256 firstL2BlockNumber = block.timestamp / 20;
-
-        // Let's create an array of contexts
-        uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
-            // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
-            contexts[i] = numTxnsPerBlock;
-
-            // Formula used for blockTimestamp: (current block.timestamp) / 5x
-            contexts[i + 1] = txnBlockTimestamp;
-
-            // The only requirement for timestamps for the transaction blocks is that, these timestamps are monotonically increasing.
-            // So, let's increase the value of txnBlock's timestamp monotonically, in a way that is does not exceed current block.timestamp
-            ++txnBlockTimestamp;
-        }
-
-        // txLengths is defined as: Array of lengths of each encoded tx in txBatch
-        // txBatch is defined as: Batch of RLP-encoded transactions
-        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTxns);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-
-        // Now, we want to trigger the `txnBatchDataOverflow`, so we want to disturn the values receieved in the txLengths array.
-        for (uint256 i; i < numTxns; i++) {
-            txLengths[i] = txLengths[i] + 1;
-        }
-
-        // Pranking as the sequencer and calling appendTxBatch (should throw the TxBatchDataOverflow error)
-        vm.expectRevert(ISequencerInbox.TxBatchDataOverflow.selector);
-        vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
+        assertEq(inboxSizeFinal, inboxSizeInitial + 1);
     }
 
     function test_appendTxBatch_paused_reverts(uint256 numTxnsPerBlock, uint256 txnBlocks) public {
@@ -258,126 +197,83 @@ contract SequencerInboxTest is SequencerBaseSetup {
         // Each context corresponds to a single "L2 block"
         uint256 numTxns = numTxnsPerBlock * txnBlocks;
         // Each `context` is represented with uint256 2-tuple: (numTxs, l2Timestamp)
-        uint256 numContextsArrEntries = 2 * txnBlocks;
+        // uint256 numContextsArrEntries = 2 * txnBlocks;
 
         // Making sure that the block.timestamp is a reasonable value (> txnBlocks)
         vm.warp(block.timestamp + (4 * txnBlocks));
-        uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
+        // uint256 txnBlockTimestamp = block.timestamp - (2 * txnBlocks); // Subtracing just `txnBlocks` would have sufficed. However we are subtracting 2 times txnBlocks for some margin of error.
         // The objective for this subtraction is that while building the `contexts` array, no timestamp should go higher than the current block.timestamp
 
-        uint256 firstL2BlockNumber = block.timestamp / 20;
+        // uint256 firstL2BlockNumber = block.timestamp / 20;
 
         // Let's create an array of contexts
-        uint256[] memory contexts = new uint256[](numContextsArrEntries);
-        for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
-            // The first entry for `contexts` for each txnBlock is `numTxns` which we are keeping as constant for all blocks for this test
-            contexts[i] = numTxnsPerBlock;
-
+        // for (uint256 i = 0; i < numContextsArrEntries; i += 2) {
             // Formula used for blockTimestamp: (current block.timestamp) / 5x
-            contexts[i + 1] = txnBlockTimestamp;
+            // contexts[i + 1] = txnBlockTimestamp;
 
             // The only requirement for timestamps for the transaction blocks is that, these timestamps are monotonically increasing.
             // So, let's increase the value of txnBlock's timestamp monotonically, in a way that is does not exceed current block.timestamp
-            ++txnBlockTimestamp;
-        }
+            // ++txnBlockTimestamp;
+        // }
 
         // txLengths is defined as: Array of lengths of each encoded tx in txBatch
         // txBatch is defined as: Batch of RLP-encoded transactions
-        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTxns);
+        bytes memory txBatch = _helper_sequencerInbox_appendTx(numTxns);
         uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
         // Pranking as the sequencer and calling appendTxBatch
         vm.prank(sequencerAddress);
         vm.expectRevert("Pausable: paused");
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
-    }
-
-    /////////////////////////////////////////////////////////////////////////////////////////
-    // TENTATIVE CODE CHANGE. TEST SUBJECT TO CHANGE BASED ON CHANGE IN CODE
-    // Probable change: `appendTxBatch` passes even with malformed `contexts` array
-    /////////////////////////////////////////////////////////////////////////////////////////
-    function test_appendTxBatch_incompleteDataInContextsArray_succeeds(uint256 numTxnsPerBlock) public {
-        // Since we are assuming that we will have two transaction blocks and we have a total of 300 sample transactions right now.
-        numTxnsPerBlock = bound(numTxnsPerBlock, 1, 150);
-        uint256 inboxSizeInitial = seqIn.getInboxSize();
-
-        uint256 firstL2BlockNumber = block.timestamp / 20;
-
-        // Each context corresponds to a single "L2 block"
-        // `contexts` is represented with uint256 3-tuple: (numTxs, l2BlockNumber, l2Timestamp)
-        // Let's create an array of contexts
-        uint256 numTxns = numTxnsPerBlock * 2;
-        uint256 timeStamp1 = block.timestamp / 10;
-
-        uint256[] memory contexts = new uint256[](3);
-
-        // Let's assume that we had 2 blocks and each had 3 transactions, but we fail to pass the block.timestamp and block.number of the 2nd transaction block.
-        contexts[0] = (numTxnsPerBlock);
-        contexts[1] = (timeStamp1);
-        contexts[2] = (numTxnsPerBlock);
-
-        // txLengths is defined as: Array of lengths of each encoded tx in txBatch
-        // txBatch is defined as: Batch of RLP-encoded transactions
-        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTxns);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
-
-        // Pranking as the sequencer and calling appendTxBatch
-        vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, firstL2BlockNumber, txBatchVersion, txBatch);
-
-        uint256 inboxSizeFinal = seqIn.getInboxSize();
-
-        assertGt(inboxSizeFinal, inboxSizeInitial);
-        assertEq(inboxSizeFinal, numTxnsPerBlock); // Since the timestamp and block.number were not included for the 2nd block, only 1st block's 3 txns are included.
+        seqIn.appendTxBatch(txBatchVersion, txBatch);
     }
 
     //////////////////////////////
     // verifyTxInclusion
     // commit a batch and verify the Nth transaction
     //////////////////////////////
-    function test_verifyTxInclusion_succeeds(uint256 numTxPerBlock, uint256 numBlocks, uint256 txToVerify) public {
-        numTxPerBlock = bound(numTxPerBlock, 1, 30);
-        numBlocks = bound(numBlocks, 1, 5);
-        uint256 numTx = numTxPerBlock * numBlocks;
+    // function test_verifyTxInclusion_succeeds(uint256 numTxPerBlock, uint256 numBlocks, uint256 txToVerify) public {
+    //     numTxPerBlock = bound(numTxPerBlock, 1, 30);
+    //     numBlocks = bound(numBlocks, 1, 5);
+    //     uint256 numTx = numTxPerBlock * numBlocks;
 
-        // append a batch of transactions to the sequencer
-        assertEq(seqIn.getInboxSize(), 0);
-        vm.warp(block.timestamp + (4 * numBlocks));
+    //     // append a batch of transactions to the sequencer
+    //     assertEq(seqIn.getInboxSize(), 0);
+    //     vm.warp(block.timestamp + (4 * numBlocks));
 
-        uint256[] memory contexts = generateContexts(numBlocks, numTxPerBlock);
+    //     uint256[] memory contexts = generateContexts(numBlocks, numTxPerBlock);
 
-        (bytes memory txBatch, uint256[] memory txLengths) = _helper_sequencerInbox_appendTx(numTx);
-        uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
+    //     bytes memory txBatch = _helper_sequencerInbox_appendTx(numTx);
+    //     uint256 txBatchVersion = _helper_sequencerInbox_appendTx_Version();
 
-        vm.prank(sequencerAddress);
-        seqIn.appendTxBatch(contexts, txLengths, 0, txBatchVersion, txBatch);
-        assertEq(seqIn.getInboxSize(), numTx);
+    //     vm.prank(sequencerAddress);
+    //     seqIn.appendTxBatch(txBatchVersion, txBatch);
+    //     assertEq(seqIn.getInboxSize(), numTx);
 
-        // randomly choose a transaction to verify and prepare the proof
-        txToVerify = bound(txToVerify, 0, numTx - 1);
+    //     // randomly choose a transaction to verify and prepare the proof
+    //     txToVerify = bound(txToVerify, 0, numTx - 1);
 
-        bytes memory txAfterData = generateTxAfterData(txToVerify, numTx, numTxPerBlock, contexts);
+    //     bytes memory txAfterData = generateTxAfterData(txToVerify, numTx, numTxPerBlock, contexts);
 
-        // prepare the encoded transaction we want to verify and its context hash
-        bytes memory encodedTx = rlpEncodedTransactions[txToVerify % 10];
+    //     // prepare the encoded transaction we want to verify and its context hash
+    //     bytes memory encodedTx = rlpEncodedTransactions[txToVerify % 10];
 
-        bytes32 proofContextHash = generateProofContextHash(txToVerify, numTxPerBlock, contexts);
+    //     bytes32 proofContextHash = generateProofContextHash(txToVerify, numTxPerBlock, contexts);
 
-        // prepare the accumulator hash of the preceding transactions in the batch
-        bytes32 accBefore = generateAccumulator(txToVerify, numTxPerBlock, contexts);
+    //     // prepare the accumulator hash of the preceding transactions in the batch
+    //     bytes32 accBefore = generateAccumulator(txToVerify, numTxPerBlock, contexts);
 
-        {
-            uint256 batchNum = 0;
-            uint256 numTxBefore = txToVerify;
-            uint256 numTxAfter = numTx - txToVerify - 1;
+    //     {
+    //         uint256 batchNum = 0;
+    //         uint256 numTxBefore = txToVerify;
+    //         uint256 numTxAfter = numTx - txToVerify - 1;
 
-            bytes memory batchInfo = abi.encodePacked(batchNum, numTxBefore, numTxAfter, accBefore);
+    //         bytes memory batchInfo = abi.encodePacked(batchNum, numTxBefore, numTxAfter, accBefore);
 
-            bytes memory proof = abi.encodePacked(proofContextHash, batchInfo, txAfterData);
+    //         bytes memory proof = abi.encodePacked(proofContextHash, batchInfo, txAfterData);
 
-            seqIn.verifyTxInclusion(encodedTx, proof);
-        }
-    }
+    //         seqIn.verifyTxInclusion(encodedTx, proof);
+    //     }
+    // }
 
     /////////////////////////
     // Auxillary Functions

--- a/contracts/test/utils/RLPEncodedTransactions.sol
+++ b/contracts/test/utils/RLPEncodedTransactions.sol
@@ -43,7 +43,7 @@ contract RLPEncodedTransactionsUtil is Test {
         return 0;
     }
 
-    // TODO: RLP encode txBatch format
+    // TODO: RLP encode txBatch format. This function encodes the old batch data format.
     function _helper_sequencerInbox_appendTx(uint256 numTxns) internal view returns (bytes memory) {
         bytes memory combinedNumTxnsBytes;
         uint256 rlpEncodedTxnIndex;

--- a/contracts/test/utils/RLPEncodedTransactions.sol
+++ b/contracts/test/utils/RLPEncodedTransactions.sol
@@ -38,14 +38,15 @@ contract RLPEncodedTransactionsUtil is Test {
         )
     ];
 
-    function _helper_sequencerInbox_appendTx_Version() internal pure returns (uint256) {
+    function _helper_sequencerInbox_appendTx_Version() internal pure returns (uint8) {
         // Update this as necessary
         return 0;
     }
 
     // TODO: RLP encode txBatch format. This function encodes the old batch data format.
     function _helper_sequencerInbox_appendTx(uint256 numTxns) internal view returns (bytes memory) {
-        bytes memory combinedNumTxnsBytes;
+        bytes memory combinedNumTxnsBytes = new bytes(1);
+        combinedNumTxnsBytes[0] = bytes1(_helper_sequencerInbox_appendTx_Version());
         uint256 rlpEncodedTxnIndex;
 
         for (uint256 i; i < numTxns; i++) {
@@ -79,7 +80,7 @@ contract RLPEncodedTransactionsUtil is Test {
     }
 
     function _helper_createTxBatch_hardcoded() internal view returns (bytes memory) {
-        return abi.encodePacked(
+        bytes memory txs = abi.encodePacked(
             RLPEncodedTransactionsUtil.rlpEncodedTransactions[0],
             RLPEncodedTransactionsUtil.rlpEncodedTransactions[1],
             RLPEncodedTransactionsUtil.rlpEncodedTransactions[2],
@@ -87,13 +88,8 @@ contract RLPEncodedTransactionsUtil is Test {
             RLPEncodedTransactionsUtil.rlpEncodedTransactions[4],
             RLPEncodedTransactionsUtil.rlpEncodedTransactions[5]
         );
-    }
-
-    function _helper_findTxLength_hardcoded() internal view returns (uint256[] memory) {
-        uint256[] memory transactionLengthArray = new uint256[](6);
-        for (uint256 i; i < 6; i++) {
-            transactionLengthArray[i] = RLPEncodedTransactionsUtil.rlpEncodedTransactions[i].length;
-        }
-        return transactionLengthArray;
+        bytes memory result = new bytes(1);
+        result[0] = 0; // tx version
+        return bytes.concat(result, txs);
     }
 }

--- a/contracts/test/utils/RLPEncodedTransactions.sol
+++ b/contracts/test/utils/RLPEncodedTransactions.sol
@@ -38,25 +38,24 @@ contract RLPEncodedTransactionsUtil is Test {
         )
     ];
 
-    function _helper_sequencerInbox_appendTx_Version() internal returns (uint256) {
+    function _helper_sequencerInbox_appendTx_Version() internal pure returns (uint256) {
         // Update this as necessary
         return 0;
     }
 
-    function _helper_sequencerInbox_appendTx(uint256 numTxns) internal view returns (bytes memory, uint256[] memory) {
-        uint256[] memory transactionLengths = new uint256[](numTxns);
+    // TODO: RLP encode txBatch format
+    function _helper_sequencerInbox_appendTx(uint256 numTxns) internal view returns (bytes memory) {
         bytes memory combinedNumTxnsBytes;
         uint256 rlpEncodedTxnIndex;
 
         for (uint256 i; i < numTxns; i++) {
             rlpEncodedTxnIndex = i % 10;
             combinedNumTxnsBytes = bytes.concat(combinedNumTxnsBytes, rlpEncodedTransactions[rlpEncodedTxnIndex]);
-            transactionLengths[i] = rlpEncodedTransactions[rlpEncodedTxnIndex].length;
         }
 
         bytes memory resultantTxnBatchBytes = abi.encodePacked(combinedNumTxnsBytes);
 
-        return (resultantTxnBatchBytes, transactionLengths);
+        return resultantTxnBatchBytes;
     }
 
     function _helper_sequencerInbox_appendTx_old(uint256 numTxns)


### PR DESCRIPTION
# Goals of PR

Create interface for batch data format, disseminate and derivate blocks using the new batch format.

Core changes:

Change the signature of appendTxBatch:

```
function appendTxBatch(    
        uint256 txBatchVersion,
        bytes calldata txBatch,
    ) external;
```

Modify the batch calldata to RLP encode transactions to the following format:
```
txBatch = rlp([first_l2_block_number, blocks]), 

block = [timestamp, transaction_list]; blocks = [block1, block2, ...],
transaction_list = [tx1, tx2, ...].
```


- Modify the sequencer to disseminate and derive RLP encoded batch data format.
- InboxSize increments by 1 each batch, instead of incrementing by the number of txs in a batch. This is because we're not currently doing any RLP decoding the SequencerInbox so we don't know the number of txs in a batch.
- Fix tests, some tests are commented out for now, some tests were no longer relevant and deleted, other tests needed to be changed to account for new InboxSize implementation.

Testing:

I tested by adding debug lines to confirm the batch format was properly RLP encoded (used this neat [tool](https://codechain-io.github.io/rlp-debugger)), and then confirmed the sequencer was able to decode and correctly derive submitted batches.

Submitted confirmed transactions via metamask.