### PR TITLE
Add script to fetch L1 block info and inject to rollup config

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -9,6 +9,8 @@ import "hardhat-deploy";
 import "@openzeppelin/hardhat-upgrades";
 import "@typechain/hardhat";
 
+import "./tasks/config_l1_timestamp";
+
 const mnemonic =
   process.env.MNEMONIC ??
   "test test test test test test test test test test test junk";

--- a/contracts/tasks/config_l1_timestamp.ts
+++ b/contracts/tasks/config_l1_timestamp.ts
@@ -1,0 +1,30 @@
+import { task } from "hardhat/config";
+import { getProxyName } from "../deploy/utils";
+import { readFileSync, write, writeFileSync } from "fs";
+
+// Usage: npx hardhat --network <l1-network> inject-l1-config --file <path-to-rollup.json>
+task("inject-l1-config", "Inject L1 deployment info to Rollup.json config file")
+  .addParam("file", "Path to Rollup.json config file")
+  .setAction(async (taskArgs, hre) => {
+    const configFile = JSON.parse(readFileSync(taskArgs.file, "utf8"));
+
+    const deployment = await hre.deployments.get(
+      getProxyName("SequencerInbox")
+    );
+    const l1BlockHash = deployment.receipt?.blockHash;
+    if (!l1BlockHash) {
+      throw Error("Could not find L1 block hash of SequencerInbox deployment");
+    }
+    const block = await hre.ethers.provider.getBlock(l1BlockHash);
+
+    if (!configFile["Genesis"]) {
+      configFile["Genesis"] = {};
+    }
+    if (!configFile["Genesis"]["L1"]) {
+      configFile["Genesis"]["L1"] = {};
+    }
+    configFile["Genesis"]["L1"]["Hash"] = l1BlockHash;
+    configFile["Genesis"]["L1"]["Number"] = block.number;
+    configFile["Genesis"]["L2Time"] = block.timestamp;
+    writeFileSync(taskArgs.file, JSON.stringify(configFile));
+  });

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["./hardhat.config.ts", "./scripts", "./deploy", "./test"]
+  "include": ["./hardhat.config.ts", "./scripts", "./deploy", "./tasks", "./test"]
 }


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add a hardhat task to fetch L1 block info and inject to rollup config

Notes:

- Usage: `npx hardhat --network <l1-network> inject-l1-config --file <path-to-rollup.json>`
