### PR TITLE
replace source with .

### DIFF
--- a/sbin/compile_contracts.sh
+++ b/sbin/compile_contracts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 SBIN=`dirname $0`
 SBIN="`cd "$SBIN"; pwd`"
 . $SBIN/configure.sh

--- a/sbin/configure.sh
+++ b/sbin/configure.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Define directory structure for other scripts.
 SBIN=$(dirname "$(readlink -f "$0")")
 SBIN="`cd "$SBIN"; pwd`"
@@ -15,4 +16,4 @@ SIDECAR_BIN=$SIDECAR_DIR/build/bin/sidecar
 GETH_BIN=$GETH_DIR/build/bin/geth
 
 # Load environment variables
-source $DATA_DIR/e2e.env
+. $DATA_DIR/e2e.env

--- a/sbin/start_l1.sh
+++ b/sbin/start_l1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SBIN_DIR=`dirname $0`
 SBIN_DIR="`cd "$SBIN_DIR"; pwd`"
-source $SBIN_DIR/configure.sh
+. $SBIN_DIR/configure.sh
 
 cd $ROOT_DIR
 


### PR DESCRIPTION
# Goals of PR

Fix the following error in the compile_contracts script:

```
sbin/compile_contracts.sh: 18: /home/user/specular/specular/sbin/configure.sh: source: not found
```

On my linux distribution, the `sh` shell is symlinked to `dash` which doesn't support the `source` builtin.

```
ls -l `which sh`
lrwxrwxrwx 1 root root 4 Jun  9  2022 /usr/bin/sh -> dash
```

I replaced the shebang in `sbin/compile_contracts.sh` with `!/bin/bash`, which fixes the issue.

I also replaced our use of `source` with the posix standard `.` for portability.