### PR TITLE
Add cache to git checkout workflow to reduce submodule checkout time 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,11 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
 
     steps:
+      - name: Cache git folder
+        uses: actions/cache@v3
+        with:
+          path: ./.git
+          key: git-folder
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -15,6 +15,12 @@ jobs:
     if: github.repository == 'SpecularL2/specular'
     runs-on: ubuntu-latest
     steps:
+      - name: Cache git folder
+        uses: actions/cache@v3
+        with:
+          path: ./.git
+          key: git-folder
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add cache to git checkout workflow to reduce submodule checkout time

Notes:

- Solution from https://github.com/actions/checkout/issues/1314#issuecomment-1587229152
