### PR TITLE
Missing dependencies for create genesis script

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -33,6 +33,14 @@ cd contracts
 Setup the environment variables needed for deployment.
 An example config for running locally can be found in `./contracts/.env.example`.
 
+## Forge install
+
+Install all required contract dependencies:
+
+```sh
+forge install
+```
+
 ## Run Tests
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@pnpm/make-dedicated-lockfile": "^0.5.0",
-    "husky": "^8.0.1"
+    "@types/node": "^18.13.0",
+    "husky": "^8.0.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,18 @@ importers:
       '@pnpm/make-dedicated-lockfile':
         specifier: ^0.5.0
         version: 0.5.0
+      '@types/node':
+        specifier: ^18.13.0
+        version: 18.14.2
       husky:
         specifier: ^8.0.1
         version: 8.0.1
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@18.14.2)(typescript@4.9.5)
+      typescript:
+        specifier: ^4.9.3
+        version: 4.9.5
 
   config:
     dependencies:
@@ -1958,7 +1967,7 @@ packages:
   /@types/readable-stream@2.3.15:
     resolution: {integrity: sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 18.14.2
       safe-buffer: 5.1.2
     dev: false
 
@@ -10343,7 +10352,6 @@ packages:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    dev: false
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Missing dependencies to run `create_genesis.sh` out-of-the-box
- README update on the contracts to include `fondry install`
- (no change) done review if there are any unnecessary pnpm ts-node installs (which is not dev-dependency)
