### PR TITLE
start geth with lower recommit interval

### DIFF
--- a/sbin/start_geth.sh
+++ b/sbin/start_geth.sh
@@ -12,6 +12,7 @@ args=(
     --http.corsdomain '*' --ws.origins '*'
     --http.vhosts '*'
     --networkid $NETWORK_ID
+    --miner.recommit 0
 )
 
 $GETH_BIN "${args[@]}"


### PR DESCRIPTION
# Goals of PR

Follow up to this [PR](https://github.com/SpecularL2/go-ethereum/pull/9): which helps enable faster block production by allowing geth to produce sealing blocks faster.

This PR changes the `start_geth` script to start our L2 execution engine (specular-geth) with `--miner.commit=0`. Geth will sanitize this value to the lowest allowed recommit interval (100ms).

We can confirm this change works because geth now starts with this line:

```
WARN [10-19|22:35:58.148] Sanitizing miner recommit interval       provided=0s updated=100ms
```

This change could affect performance at startup, but if geth isn't able to fill blocks within this interval, there is logic to adjust this value higher.