### PR TITLE
use l1 safe block for l2 genesis timestamp

### DIFF
--- a/sbin/create_genesis.sh
+++ b/sbin/create_genesis.sh
@@ -25,8 +25,49 @@ relpath () {
 BASE_GENESIS_PATH=`relpath $BASE_GENESIS_PATH $CONFIG_DIR`
 GENESIS_PATH=`relpath $GENESIS_PATH $CONFIG_DIR`
 
+L1_WS_PORT=`echo $L1_ENDPOINT | awk -F':' '{print $3}'`
+echo "Parsed port: $L1_WS_PORT from $L1_ENDPOINT"
+
+# Start an L1 if one isn't already running
+if ! ss -tuln | grep -q ":$L1_WS_PORT "; then
+    echo "Starting L1..."
+    if [ $L1_STACK = "geth" ]; then
+        $GETH_BIN \
+        --dev \
+        --dev.period 1 \
+        --verbosity 3 \
+        --http \
+        --http.api eth,web3,net \
+        --http.addr 0.0.0.0 \
+        --ws \
+        --ws.api eth,net,web3 \
+        --ws.addr 0.0.0.0 \
+        --ws.port $L1_WS_PORT > /dev/null 2>&1 &
+        sleep 3
+        L1_PID=$!
+
+    elif [ $L1_STACK = "hardhat" ]; then
+        cd $CONTRACTS_DIR && npx hardhat node --no-deploy --port $L1_WS_PORT &
+        L1_PID=$!
+        echo "L1 PID: $L1_PID"
+        sleep 3
+    else
+        echo "invalid value for L1_STACK: $L1_STACK"
+        exit 1
+    fi
+else
+    L1_PID=0
+    echo "L1 already started..."
+fi
+
+
 # Create genesis.json file.
-cd $CONFIG_DIR && npx ts-node src/create_genesis.ts --in $BASE_GENESIS_PATH --out $GENESIS_PATH
+cd $CONFIG_DIR && npx ts-node src/create_genesis.ts --in $BASE_GENESIS_PATH --out $GENESIS_PATH --l1network "$L1_ENDPOINT"
+
+if [ $L1_PID -ne 0 ]; then
+    echo "Stopping L1"
+    kill $L1_PID
+fi
 
 # If the contracts directory exists, initialize a reference to the genesis file at
 # "contracts/.genesis" (using relative paths as appropriate).


### PR DESCRIPTION
# Goals of PR

This PR uses the L1 safe block, as the timestamp for the L2 genesis file.

after this change, `genesis.json` should have the following field, with a non-zero value:

```"timestamp": 1698446636```

now create_genesis.ts expects an `--l1network` flag which is used to fetch the latest safe block. `create_genesis.sh` creates and destroys an L1, if one isn't already running for `create_genesis.ts`

I tested to confirm the new genesis.json file has a similar timestamp to the latest l1 safe block

```
services/el_clients/go-ethereum/build/bin/geth attach -exec "eth.getBlockByNumber('latest').timestamp" ws://172.17.0.1:8545
```