### PR TITLE
enableL2GasLimitApi

### DIFF
--- a/config/local_devnet/base_genesis.json
+++ b/config/local_devnet/base_genesis.json
@@ -16,7 +16,8 @@
     "grayGlacierBlock": 0,
     "MergeNetsplitBlock": 0,
     "TerminalTotalDifficulty": 0,
-    "TerminalTotalDifficultyPassed": true
+    "TerminalTotalDifficultyPassed": true,
+    "enableL2GasLimitApi": true
   },
   "difficulty": "0",
   "gasLimit": "8000000",


### PR DESCRIPTION
# Goals of PR

Follow up to this [PR](https://github.com/MoonShiesty/go-ethereum/tree/gas-limit) to enableL2GasLimitApi in the chain config via `genesis.json`. I also updated sp-geth to 

when this feature is enabled, sp-geth should log this on startup:

```
Consensus: L2 gas limit API enabled
```

I also updated the sp-geth submodule to the latest