### PR TITLE
Ensure L1Oracle block number increases monotonically

### DIFF
--- a/contracts/src/bridge/L1Oracle.sol
+++ b/contracts/src/bridge/L1Oracle.sol
@@ -70,6 +70,7 @@ contract L1Oracle is Initializable, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         onlyCoinbase
         whenNotPaused
     {
+        require(number < _number, "Block number must be greater than the current block number.");
         number = _number;
         timestamp = _timestamp;
         baseFee = _baseFee;


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add a `require` state to ensure L1Oracle block number increases monotonically
  - So that the sequencer can not modify the oracle values in the middle of the batch undetected
