### PR TITLE
Version assertion

### DIFF
--- a/contracts/src/IRollup.sol
+++ b/contracts/src/IRollup.sol
@@ -134,7 +134,7 @@ interface IRollup {
     }
 
     struct Assertion {
-        bytes32 stateHash; // Hash of execution state associated with assertion. Currently equiv to `vmHash`.
+        bytes32 stateCommitment; // Versioned execution state associated with assertion. Currently equiv to `keccak256(version || vmHash)`.
         uint256 blockNum; // Block number this assertion advanced to
         uint256 parent; // Parent assertion ID
         uint256 deadline; // Dispute deadline (L1 block number)
@@ -308,10 +308,10 @@ interface IRollup {
      *
      * Emits: `AssertionCreated` and `StakerStaked` events.
      *
-     * @param vmHash New VM hash.
-     * @param inboxSize Size of inbox corresponding to assertion (number of transactions).
+     * @param stateCommitment Currently keccak256(version || vmHash)
+     * @param blockNum Block number this assertion advances to.
      */
-    function createAssertion(bytes32 vmHash, uint256 inboxSize) external;
+    function createAssertion(bytes32 stateCommitment, uint256 blockNum) external;
 
     /**
      * @notice Initiates a dispute between a defender and challenger on an unconfirmed DA.

--- a/contracts/src/bridge/L1Portal.sol
+++ b/contracts/src/bridge/L1Portal.sol
@@ -147,7 +147,7 @@ contract L1Portal is
         IRollup.Assertion memory assertion = rollup.getAssertion(assertionID);
 
         // Ensure that the assertion is confirmed.
-        require(_isAssertionConfirmed(assertionID, assertion.stateHash), "L1Portal: assertion not confirmed");
+        require(_isAssertionConfirmed(assertionID, assertion.stateCommitment), "L1Portal: assertion not confirmed");
 
         // All withdrawals have a unique hash, we'll use this as the identifier for the withdrawal
         // and to prevent replay attacks.
@@ -165,7 +165,7 @@ contract L1Portal is
 
             // Verify the account proof.
             bytes32 storageRoot =
-                _verifyAccountInclusion(Predeploys.L2_PORTAL, assertion.stateHash, withdrawalAccountProof);
+                _verifyAccountInclusion(Predeploys.L2_PORTAL, assertion.stateCommitment, withdrawalAccountProof);
 
             // Verify that the hash of this withdrawal was stored in the L2Portal contract on L2.
             // If this is true, then we know that this withdrawal was actually triggered on L2
@@ -206,7 +206,7 @@ contract L1Portal is
     /// @inheritdoc IL1Portal
     function isAssertionConfirmed(uint256 assertionID) public view override returns (bool) {
         IRollup.Assertion memory assertion = rollup.getAssertion(assertionID);
-        return _isAssertionConfirmed(assertionID, assertion.stateHash);
+        return _isAssertionConfirmed(assertionID, assertion.stateCommitment);
     }
 
     /// @inheritdoc IL1Portal
@@ -248,16 +248,16 @@ contract L1Portal is
      * @notice Determine if a given assertion is finalized and confirmed.
      *
      * @param assertionID The ID of the assertion.
-     * @param stateHash   The stateHash field of the assertion.
+     * @param stateCommitment The state commitment field of the assertion.
      */
-    function _isAssertionConfirmed(uint256 assertionID, bytes32 stateHash) internal view returns (bool) {
+    function _isAssertionConfirmed(uint256 assertionID, bytes32 stateCommitment) internal view returns (bool) {
         // Must be finalized.
         if (assertionID > rollup.getLastConfirmedAssertionID()) {
             return false;
         }
 
         // Must be confirmed.
-        if (stateHash == bytes32(0)) {
+        if (stateCommitment == bytes32(0)) {
             return false;
         }
 

--- a/contracts/test/Rollup.t.sol
+++ b/contracts/test/Rollup.t.sol
@@ -721,8 +721,8 @@ contract RollupTest is RollupBaseSetup {
 
         _appendTxBatch();
 
-        bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 1;
+        bytes32 mockStateCommitment = bytes32(hex"00");
+        uint256 mockBlockNum = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -733,7 +733,7 @@ contract RollupTest is RollupBaseSetup {
         assertEq(assertionIDInitial, 0);
 
         vm.prank(alice);
-        rollup.createAssertion(mockVmHash, mockInboxSize);
+        rollup.createAssertion(mockStateCommitment, mockBlockNum);
 
         // The assertionID of alice should change after she called `createAssertion`
         (,, uint256 assertionIDFinal,) = rollup.stakers(address(alice));
@@ -889,11 +889,11 @@ contract RollupTest is RollupBaseSetup {
 
         _appendTxBatch();
 
-        bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 1;
+        bytes32 mockStateCommitment = bytes32(hex"00");
+        uint256 mockBlockNum = 1;
 
         vm.prank(alice);
-        rollup.createAssertion(mockVmHash, mockInboxSize);
+        rollup.createAssertion(mockStateCommitment, mockBlockNum);
 
         // The assertionID of alice should change after she called `createAssertion`
         (,, uint256 assertionIDFinal,) = rollup.stakers(address(alice));
@@ -981,8 +981,8 @@ contract RollupTest is RollupBaseSetup {
         // Increase the sequencerInbox inboxSize with mock transactions we can assert on.
         _appendTxBatch();
 
-        bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 1;
+        bytes32 mockStateCommitment = bytes32(hex"00");
+        uint256 mockBlockNum = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -990,7 +990,7 @@ contract RollupTest is RollupBaseSetup {
         assertEq(rollup.lastCreatedAssertionID(), 0, "The lastCreatedAssertionID should be 0 (genesis)");
 
         vm.prank(alice);
-        rollup.createAssertion(mockVmHash, mockInboxSize);
+        rollup.createAssertion(mockStateCommitment, mockBlockNum);
 
         // A successful assertion should bump the lastCreatedAssertionID to 1.
         assertEq(rollup.lastCreatedAssertionID(), 1, "LastCreatedAssertionID not updated correctly");
@@ -1047,8 +1047,8 @@ contract RollupTest is RollupBaseSetup {
         // Increase the sequencerInbox inboxSize with mock transactions we can assert on.
         _appendTxBatch();
 
-        bytes32 mockVmHash = bytes32("");
-        uint256 mockInboxSize = 1;
+        bytes32 mockStateCommitment = bytes32(hex"00");
+        uint256 mockBlockNum = 1;
 
         // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
         vm.roll(block.number + rollup.minimumAssertionPeriod());
@@ -1062,7 +1062,7 @@ contract RollupTest is RollupBaseSetup {
         // try as alice
         vm.expectRevert("Pausable: paused");
         vm.prank(alice);
-        rollup.createAssertion(mockVmHash, mockInboxSize);
+        rollup.createAssertion(mockStateCommitment, mockBlockNum);
 
         // unpause and continue setup
         vm.prank(deployer);
@@ -1070,7 +1070,7 @@ contract RollupTest is RollupBaseSetup {
 
         // try again now that pause is over
         vm.prank(alice);
-        rollup.createAssertion(mockVmHash, mockInboxSize);
+        rollup.createAssertion(mockStateCommitment, mockBlockNum);
 
         // A successful assertion should bump the lastCreatedAssertionID to 1.
         assertEq(rollup.lastCreatedAssertionID(), 1, "LastCreatedAssertionID not updated correctly");
@@ -1194,14 +1194,14 @@ contract RollupTest is RollupBaseSetup {
 
             _appendTxBatch();
 
-            bytes32 mockVmHash = bytes32("");
-            uint256 mockInboxSize = 1;
+            bytes32 mockStateCommitment = bytes32(hex"00");
+            uint256 mockBlockNum = 1;
 
             // To avoid the MinimumAssertionPeriodNotPassed error, increase block.number
             vm.roll(block.number + rollup.minimumAssertionPeriod());
 
             vm.prank(alice);
-            rollup.createAssertion(mockVmHash, mockInboxSize);
+            rollup.createAssertion(mockStateCommitment, mockBlockNum);
         }
 
         uint256 defenderAssertionID = lastConfirmedAssertionID; //would be 0 in this case. cannot assign anything lower

--- a/services/sidecar/rollup/rpc/bridge/serialization.go
+++ b/services/sidecar/rollup/rpc/bridge/serialization.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/specularL2/specular/services/sidecar/bindings"
+	specularTypes "github.com/specularL2/specular/services/sidecar/rollup/types"
 	"github.com/specularL2/specular/services/sidecar/utils/fmt"
 )
 
@@ -55,16 +56,14 @@ func packAppendTxBatchInput(batch []byte) ([]byte, error) {
 
 // IRollup.sol
 
-func UnpackCreateAssertionInput(tx *types.Transaction) (common.Hash, *big.Int, error) {
+func UnpackCreateAssertionInput(tx *types.Transaction) (specularTypes.Bytes32, *big.Int, error) {
 	in, err := serializationUtil.rollupAbi.Methods[CreateAssertionFnName].Inputs.Unpack(tx.Data()[MethodNumBytes:])
 	if err != nil {
-		return common.Hash{}, nil, err
+		return specularTypes.Bytes32{}, nil, err
 	}
-	var (
-		vmHash    = in[0].(common.Hash)
-		inboxSize = in[1].(*big.Int)
-	)
-	return vmHash, inboxSize, err
+	stateCommitment := in[0].(specularTypes.Bytes32)
+	blockNum := in[1].(*big.Int)
+	return stateCommitment, blockNum, err
 }
 
 func packStakeInput() ([]byte, error) {
@@ -75,8 +74,8 @@ func packAdvanceStakeInput(assertionID *big.Int) ([]byte, error) {
 	return serializationUtil.rollupAbi.Pack(AdvanceStakeFnName, assertionID)
 }
 
-func packCreateAssertionInput(vmHash common.Hash, blockNum *big.Int) ([]byte, error) {
-	return serializationUtil.rollupAbi.Pack(CreateAssertionFnName, vmHash, blockNum)
+func packCreateAssertionInput(stateCommitment specularTypes.Bytes32, blockNum *big.Int) ([]byte, error) {
+	return serializationUtil.rollupAbi.Pack(CreateAssertionFnName, stateCommitment, blockNum)
 }
 
 func packConfirmFirstUnresolvedAssertionInput() ([]byte, error) {

--- a/services/sidecar/rollup/rpc/bridge/tx_mgr.go
+++ b/services/sidecar/rollup/rpc/bridge/tx_mgr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/specularL2/specular/services/sidecar/rollup/rpc/eth/txmgr"
+	specularTypes "github.com/specularL2/specular/services/sidecar/rollup/types"
 )
 
 // Adds bridge contract method bindings to EthTxManager.
@@ -61,8 +62,8 @@ func (m *TxManager) AdvanceStake(ctx context.Context, assertionID *big.Int) (*ty
 	return m.sendRollupTx(ctx, data, 0)
 }
 
-func (m *TxManager) CreateAssertion(ctx context.Context, vmHash common.Hash, blockNum *big.Int) (*types.Receipt, error) {
-	data, err := packCreateAssertionInput(vmHash, blockNum)
+func (m *TxManager) CreateAssertion(ctx context.Context, stateCommitment specularTypes.Bytes32, blockNum *big.Int) (*types.Receipt, error) {
+	data, err := packCreateAssertionInput(stateCommitment, blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sidecar/rollup/services/validator/interface.go
+++ b/services/sidecar/rollup/services/validator/interface.go
@@ -20,7 +20,7 @@ type Config interface {
 type TxManager interface {
 	Stake(ctx context.Context, stakeAmount *big.Int) (*ethTypes.Receipt, error)
 	AdvanceStake(ctx context.Context, assertionID *big.Int) (*ethTypes.Receipt, error)
-	CreateAssertion(ctx context.Context, vmHash common.Hash, inboxSize *big.Int) (*ethTypes.Receipt, error)
+	CreateAssertion(ctx context.Context, stateCommitment types.Bytes32, blockNum *big.Int) (*ethTypes.Receipt, error)
 	ConfirmFirstUnresolvedAssertion(ctx context.Context) (*ethTypes.Receipt, error)
 }
 

--- a/services/sidecar/rollup/services/validator/state_commitment.go
+++ b/services/sidecar/rollup/services/validator/state_commitment.go
@@ -1,0 +1,70 @@
+package validator
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/specularL2/specular/services/sidecar/rollup/types"
+)
+
+var (
+	ErrInvalidStateCommitment        = errors.New("invalid state commitment")
+	ErrInvalidStateCommitmentVersion = errors.New("invalid state commitment version")
+
+	StateCommitmentVersionV0 = types.Bytes32{}
+)
+
+type VersionedStateCommitment interface {
+	// Version returns the version of the L2 state commitment
+	Version() types.Bytes32
+
+	// Marshal a L2 state commitment into a byte slice for hashing
+	Marshal() []byte
+}
+
+type StateCommitmentV0 struct {
+	l2VmHash common.Hash
+}
+
+func (o *StateCommitmentV0) Version() types.Bytes32 {
+	return StateCommitmentVersionV0
+}
+
+func (o *StateCommitmentV0) Marshal() []byte {
+	var buf [64]byte
+	version := o.Version()
+	copy(buf[:32], version[:])
+	copy(buf[32:], o.l2VmHash[:])
+	return buf[:]
+}
+
+// StateCommitment returns the keccak256 hash of the marshaled L2 state commitment
+func StateCommitment(stateCommitment VersionedStateCommitment) types.Bytes32 {
+	marshaled := stateCommitment.Marshal()
+	return types.Bytes32(crypto.Keccak256Hash(marshaled))
+}
+
+func UnmarshalStateCommitment(data []byte) (VersionedStateCommitment, error) {
+	if len(data) < 32 {
+		return nil, ErrInvalidStateCommitment
+	}
+	var ver types.Bytes32
+	copy(ver[:], data[:32])
+	switch ver {
+	case StateCommitmentVersionV0:
+		return unmarshalStateCommitmentV0(data)
+	default:
+		return nil, ErrInvalidStateCommitmentVersion
+	}
+}
+
+func unmarshalStateCommitmentV0(data []byte) (*StateCommitmentV0, error) {
+	if len(data) != 64 {
+		return nil, ErrInvalidStateCommitment
+	}
+	var l2State StateCommitmentV0
+	// data[:32] is the version
+	copy(l2State.l2VmHash[:], data[32:64])
+	return &l2State, nil
+}

--- a/services/sidecar/rollup/services/validator/validator.go
+++ b/services/sidecar/rollup/services/validator/validator.go
@@ -35,8 +35,8 @@ type Validator struct {
 }
 
 type assertionAttributes struct {
-	l2BlockNum      uint64
-	stateCommitment specularTypes.Bytes32
+	l2BlockNum        uint64
+	l2StateCommitment specularTypes.Bytes32
 }
 
 func NewValidator(
@@ -119,7 +119,7 @@ func (v *Validator) createAssertion(ctx context.Context) error {
 	cCtx, cancel := context.WithTimeout(ctx, transactTimeout)
 	defer cancel()
 	// TOOD: GasLimit: 0 ...?
-	receipt, err := v.l1TxMgr.CreateAssertion(cCtx, assertionAttrs.stateCommitment, big.NewInt(0).SetUint64(assertionAttrs.l2BlockNum))
+	receipt, err := v.l1TxMgr.CreateAssertion(cCtx, assertionAttrs.l2StateCommitment, big.NewInt(0).SetUint64(assertionAttrs.l2BlockNum))
 	if err != nil {
 		return err
 	}

--- a/services/sidecar/rollup/types/assertion.go
+++ b/services/sidecar/rollup/types/assertion.go
@@ -2,27 +2,27 @@ package types
 
 import (
 	"math/big"
-
-	"github.com/ethereum/go-ethereum/common"
 )
+
+type Bytes32 [32]byte
 
 // Assertion represents disputable assertion for L1 rollup contract
 type Assertion struct {
-	ID         *big.Int
-	VmHash     common.Hash
-	BlockNum   *big.Int
-	Deadline   *big.Int
-	StartBlock uint64
-	EndBlock   uint64
+	ID              *big.Int
+	StateCommitment Bytes32
+	BlockNum        *big.Int
+	Deadline        *big.Int
+	StartBlock      uint64
+	EndBlock        uint64
 }
 
 func (a *Assertion) Copy() *Assertion {
 	return &Assertion{
-		ID:         new(big.Int).Set(a.ID),
-		VmHash:     a.VmHash,
-		BlockNum:   new(big.Int).Set(a.BlockNum),
-		Deadline:   new(big.Int).Set(a.Deadline),
-		StartBlock: a.StartBlock,
-		EndBlock:   a.EndBlock,
+		ID:              new(big.Int).Set(a.ID),
+		StateCommitment: a.StateCommitment,
+		BlockNum:        new(big.Int).Set(a.BlockNum),
+		Deadline:        new(big.Int).Set(a.Deadline),
+		StartBlock:      a.StartBlock,
+		EndBlock:        a.EndBlock,
 	}
 }


### PR DESCRIPTION
# Goals of PR

Version assertion data, which currently is currently equivalent to vmHash.

- Describe changes here

Prepend a version byte to assertion data, and store as a blob and modify validator to publish new versioned assertion data blob format.

- Write notes here

These changes increase the size of `Rollup.sol` over the transaction size limit (by ~100 with optimizer on and 1 run). We'll have to split up `Rollup.sol` to deploy these changes.

The decoding versioned assertion data cannot revert or validators will be unable to challange assertions with invalid encoding. 