### PR TITLE
wait for block number instead of state root

### DIFF
--- a/contracts/scripts/e2e/bridge/test_standard_bridge_deposit_eth.ts
+++ b/contracts/scripts/e2e/bridge/test_standard_bridge_deposit_eth.ts
@@ -5,7 +5,7 @@ import {
   getSignersAndContracts,
   getDepositProof,
   hexlifyBlockNum,
-  waitUntilStateRoot,
+  waitUntilOracleBlock,
 } from "../utils";
 
 async function main() {
@@ -43,15 +43,8 @@ async function main() {
     data: depositEvent.args.data,
   };
 
-  let blockNumber = await l1Provider.getBlockNumber();
-  let rawBlock = await l1Provider.send("eth_getBlockByNumber", [
-    ethers.utils.hexValue(blockNumber),
-    false, // We only want the block header
-  ]);
-  let stateRoot = l1Provider.formatter.hash(rawBlock.stateRoot);
-
-  console.log("Initial block", { blockNumber, stateRoot, depositEvent });
-  await waitUntilStateRoot(l1Oracle, stateRoot);
+  let depositBlockNumber = await l1Provider.getBlockNumber();
+  await waitUntilOracleBlock(l1Oracle, depositBlockNumber);
 
   console.log({ depositHash: depositEvent.args.depositHash });
   const initiated = await l1Portal.initiatedDeposits(
@@ -62,12 +55,12 @@ async function main() {
   const depositProof = await getDepositProof(
     l1Portal.address,
     depositEvent.args.depositHash,
-    hexlifyBlockNum(blockNumber),
+    hexlifyBlockNum(depositBlockNumber),
   );
 
   try {
     const finalizeTx = await l2Portal.finalizeDepositTransaction(
-      blockNumber,
+      depositBlockNumber,
       despositMessage,
       depositProof.accountProof,
       depositProof.storageProof,

--- a/contracts/scripts/e2e/bridge/test_standard_bridge_erc20.ts
+++ b/contracts/scripts/e2e/bridge/test_standard_bridge_erc20.ts
@@ -5,7 +5,7 @@ import {
   getWithdrawalProof,
   deployTokenPair,
   hexlifyBlockNum,
-  waitUntilStateRoot,
+  waitUntilOracleBlock,
   waitUntilBlockConfirmed,
 } from "../utils";
 
@@ -74,7 +74,7 @@ async function main() {
   const stateRoot = l1Provider.formatter.hash(rawBlock.stateRoot);
 
   console.log("Initial block", { blockNumber, stateRoot, depositMessage });
-  await waitUntilStateRoot(l1Oracle, stateRoot);
+  await waitUntilOracleBlock(l1Oracle, blockNumber);
 
   console.log({ depositHash: depositEvent.args.depositHash });
   let initiated = await l1Portal.initiatedDeposits(

--- a/contracts/scripts/e2e/utils.ts
+++ b/contracts/scripts/e2e/utils.ts
@@ -183,21 +183,19 @@ export function getStorageKey(messageHash: string) {
 }
 
 /**
- * Blocking function that only exits once the L1 state root has been relayed by L1Oracle
- * Note that it is possible for the oracle to skip L1 blocks, in this case this function never exits
+ * Blocking function that only exits once the block relayed by L1Oracle is >= the blockNumber
  * @param {Contract} l1Oracle - the oracle contract deployed on L2
- * @param {string} stateRoot - the state root we are waiting for
+ * @param {number} blockNumber - the block we are waiting for
  */
-export async function waitUntilStateRoot(
+export async function waitUntilOracleBlock(
   l1Oracle: Contract,
-  stateRoot: string,
+  blockNumber: number,
 ) {
-  console.log(`Waiting for L2 state root ${stateRoot}...`);
-
-  let oracleStateRoot = await l1Oracle.stateRoot();
-  while (oracleStateRoot !== stateRoot) {
-    oracleStateRoot = await l1Oracle.stateRoot();
+  console.log(`Waiting for L1Oracle to relay block #${blockNumber}...`);
+  let oracleBlockNumber = await l1Oracle.number();
+  while (oracleBlockNumber < blockNumber) {
     await delay(500);
+    oracleBlockNumber = await l1Oracle.number();
   }
 }
 


### PR DESCRIPTION
# Goals of PR

Core changes:
- oracle can skip blocks, we need to wait until `L1Oracle.number >= depositTxBlock`