### PR TITLE
Fix genesis generation

### DIFF
--- a/contracts/scripts/config/create_deployments_config.ts
+++ b/contracts/scripts/config/create_deployments_config.ts
@@ -35,6 +35,7 @@ export async function generateContractAddresses(
         .replace(/([a-z])([A-Z])/g, "$1_$2")
         .toUpperCase();
       result += `${contractName}_ADDR=${deployment.address}\n`;
+      result += `${contractName}_DEPLOYED_BLOCK=${deployment.receipt.blockNumber}\n`;
     }
   }
   fs.writeFileSync(deploymentsConfigPath, result);

--- a/sbin/create_genesis.sh
+++ b/sbin/create_genesis.sh
@@ -27,6 +27,7 @@ guard_overwrite $GENESIS_PATH $AUTO_ACCEPT
 FLAGS=(
   "--genesis-config $GENESIS_CFG_PATH"
   "--out $GENESIS_PATH"
+  "--l1-block $SEQUENCER_INBOX_DEPLOYED_BLOCK"
   "--l1-rpc-url $L1_ENDPOINT"
   "--export-hash $GENESIS_EXPORTED_HASH_PATH"
   "--l1-portal-address $L1PORTAL_ADDR"


### PR DESCRIPTION
# Goals of PR

Core changes:

- Use the L1 block where `SequencerInbox` is deployed to generate genesis

