### PR TITLE
contract pausing / upgrades

### DIFF
--- a/contracts/scripts/e2e/utils.ts
+++ b/contracts/scripts/e2e/utils.ts
@@ -3,11 +3,11 @@ import { Wallet, BigNumber, Contract } from "ethers";
 import { ethers } from "hardhat";
 
 const l1Provider = new ethers.providers.JsonRpcProvider(
-  process.env.L2_RPC_URL || "http://localhost:8545",
+  process.env.L1_RPC_URL || "http://localhost:8545",
 );
 
 const l2Provider = new ethers.providers.JsonRpcProvider(
-  process.env.L1_RPC_URL || "http://localhost:4011",
+  process.env.L2_RPC_URL || "http://localhost:4011",
 );
 
 const l1BridgeAddress = process.env.L1STANDARD_BRIDGE_ADDR || "invalid address";

--- a/sbin/pause.sh
+++ b/sbin/pause.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# the local sbin paths are relative to the project root
+SBIN=$(dirname "$(readlink -f "$0")")
+SBIN="$(
+  cd "$SBIN"
+  pwd
+)"
+. $SBIN/utils/utils.sh
+ROOT_DIR=$SBIN/..
+
+reqdotenv "paths" ".paths.env"
+reqdotenv "deployments" ".deployments.env"
+
+cd $CONTRACTS_DIR
+npx hardhat run scripts/pause.ts

--- a/services/sidecar/rollup/services/validator/validator.go
+++ b/services/sidecar/rollup/services/validator/validator.go
@@ -102,13 +102,15 @@ func (v *Validator) start(ctx context.Context) error {
 
 // Attempts to create a new assertion and confirm an existing assertion.
 func (v *Validator) step(ctx context.Context) error {
+	// resolve assertions first - when the contracts are paused creating assertions will fail
+	// but we still want to be able to resolve the remaining unresolved assertions
+	if err := v.resolveFirstUnresolvedAssertion(ctx); err != nil {
+		return fmt.Errorf("failed to resolve assertion: %w", err)
+	}
 	// Try to create a new assertion.
 	// TODO: do this only if configured to be an active validator.
 	if err := v.tryCreateAssertion(ctx); err != nil {
 		return fmt.Errorf("failed to create assertion: %w", err)
-	}
-	if err := v.resolveFirstUnresolvedAssertion(ctx); err != nil {
-		return fmt.Errorf("failed to resolve assertion: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Goals of PR

- uses existing utils script for pausing all L1 contracts
- pausing the contracts is required before updating contract implementations
- the change to sidecar is necessary because updates can only happen when `lastAssertionID == lastConfirmedAssertionID` - thus we need to keep confirming assertions even if we can't create new ones 

the general update flow:
```
# pause contracts
cd $WORKSPACE_DIR
OWNER_PRIVATE_KEY=$(cat deployer_pk.txt) ../sbin/pause.sh

# deploy upgrades
cd $CONTRACTS_DIR
yes | npx hardhat deploy --network localhost

# unpause contracts
cd $WORKSPACE_DIR
OWNER_PRIVATE_KEY=$(cat deployer_pk.txt) UNPAUSE=true ../sbin/pause.sh
```

note: for testing on localhost the `live` property must be set to true in the hardhat config